### PR TITLE
Switch errAssociationClosed to io.EOF

### DIFF
--- a/association.go
+++ b/association.go
@@ -23,8 +23,6 @@ const (
 	dataChunkHeaderSize  uint32 = 16
 )
 
-var errAssociationClosed = errors.Errorf("The association is closed")
-
 // association state enums
 const (
 	closed uint32 = iota
@@ -1018,7 +1016,7 @@ func (a *Association) OpenStream(streamIdentifier uint16, defaultPayloadType Pay
 func (a *Association) AcceptStream() (*Stream, error) {
 	s, ok := <-a.acceptCh
 	if !ok {
-		return nil, errAssociationClosed
+		return nil, io.EOF // no more incoming streams
 	}
 	return s, nil
 }


### PR DESCRIPTION
This is the log we have been seeing:

```
ortc ERROR: 2019/05/08 09:49:25 Failed to accept data channel: The association is closed
```

#### Description
Currently, association.AcceptStream() returns errAssociationClosed and that is the only error it returns. This error returns only when association.Close() is called, and it is expected that AcceptStream() will also immediately return with the error. When SCTPTransport sees this error, it does log.Errorf() which has been annoying users.
A suggested solution is to return io.EOF instead to indicate "no more incoming stream", so that SCTPTransport can suppress the log when the error is io.EOF. 

#### Reference issue
Relates to pion/webrt#664
