### PR TITLE
Patch to properly return an io.ErrShortBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Michael MacDonald](https://github.com/mjmac) - *Fix races*
 * [Yutaka Takeda](https://github.com/enobufs) - *PR-SCTP, Retransmissions, Congestion Control*
 * [Antoine Baché](https://github.com/Antonito) - *SCTP Profiling*
+* [Cecylia Bocovich](https://github.com/cohosh) - *Fix SCTP reads*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/stream.go
+++ b/stream.go
@@ -2,6 +2,7 @@ package sctp
 
 import (
 	"fmt"
+	"io"
 	"math"
 	"sync"
 
@@ -94,6 +95,8 @@ func (s *Stream) ReadSCTP(p []byte) (int, PayloadProtocolIdentifier, error) {
 		n, ppi, err := s.reassemblyQueue.read(p)
 		if err == nil {
 			return n, ppi, nil
+		} else if err == io.ErrShortBuffer {
+			return 0, PayloadProtocolIdentifier(0), err
 		}
 
 		err = s.readErr


### PR DESCRIPTION
If the reassemblyQueue returns an io.ErrShortBuffer, this error is
returned instead of being overwritten and lost

#### Description

Since the datachannel read loop https://github.com/pion/webrtc/blob/master/datachannel.go#L292 is checking for io.ErrShortBuffer errors, the best thing to do is simply return this error from Stream.ReadSCTP
 and let the calling functions handle it.

See https://trac.torproject.org/projects/tor/ticket/28942#comment:15

#### Reference issue
Fixes #50 
