### PR TITLE
Store stream name

### DIFF
--- a/association.go
+++ b/association.go
@@ -1031,7 +1031,9 @@ func (a *Association) createStream(streamIdentifier uint16, accept bool) *Stream
 		streamIdentifier: streamIdentifier,
 		reassemblyQueue:  newReassemblyQueue(streamIdentifier),
 		log:              a.log,
+		name:             fmt.Sprintf("%d:%s", streamIdentifier, a.name),
 	}
+
 	s.readNotifier = sync.NewCond(&s.lock)
 
 	if accept {


### PR DESCRIPTION
Small optimization: prevent the execution of a string formatting
operation for each log line using stream name.