### PR TITLE
Fix unordered message corruption

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -1183,8 +1183,11 @@ func TestHandleForwardTSN(t *testing.T) {
 
 		p := a.handleForwardTSN(fwdtsn)
 
+		a.lock.Lock()
+		ackState := a.ackState
+		a.lock.Unlock()
 		assert.Equal(t, a.peerLastTSN, prevTSN+3, "peerLastTSN should advance by 3 ")
-		assert.Equal(t, ackStateDelay, a.ackState, "delayed sack should be requested")
+		assert.Equal(t, ackStateDelay, ackState, "delayed sack should be requested")
 		assert.Nil(t, p, "should return nil")
 	})
 
@@ -1215,8 +1218,11 @@ func TestHandleForwardTSN(t *testing.T) {
 
 		p := a.handleForwardTSN(fwdtsn)
 
+		a.lock.Lock()
+		ackState := a.ackState
+		a.lock.Unlock()
 		assert.Equal(t, a.peerLastTSN, prevTSN+2, "peerLastTSN should advance by 3")
-		assert.Equal(t, ackStateDelay, a.ackState, "delayed sack should be requested")
+		assert.Equal(t, ackStateDelay, ackState, "delayed sack should be requested")
 		assert.Nil(t, p, "should return nil")
 	})
 
@@ -1247,8 +1253,12 @@ func TestHandleForwardTSN(t *testing.T) {
 
 		p := a.handleForwardTSN(fwdtsn)
 
+		a.lock.Lock()
+		ackState := a.ackState
+		a.lock.Unlock()
 		assert.Equal(t, a.peerLastTSN, prevTSN+1, "peerLastTSN should advance by 1")
-		assert.Equal(t, ackStateImmediate, a.ackState, "immediate sack should be requested")
+		assert.Equal(t, ackStateImmediate, ackState, "immediate sack should be requested")
+
 		assert.Nil(t, p, "should return nil")
 	})
 
@@ -1269,8 +1279,11 @@ func TestHandleForwardTSN(t *testing.T) {
 
 		p := a.handleForwardTSN(fwdtsn)
 
+		a.lock.Lock()
+		ackState := a.ackState
+		a.lock.Unlock()
 		assert.Equal(t, a.peerLastTSN, prevTSN, "peerLastTSN should not advance")
-		assert.Equal(t, ackStateImmediate, a.ackState, "sack should be requested")
+		assert.Equal(t, ackStateImmediate, ackState, "sack should be requested")
 		assert.Nil(t, p, "should return nil")
 	})
 }

--- a/association_test.go
+++ b/association_test.go
@@ -38,10 +38,9 @@ func stressDuplex(t *testing.T) {
 
 	defer stop(t)
 
-	// TODO: Increase once SCTP is more reliable in case of slow reader
 	opt := test.Options{
-		MsgSize:  2048, // 65535,
-		MsgCount: 10,   // 1000,
+		MsgSize:  65535,
+		MsgCount: 1000,
 	}
 
 	err = test.StressDuplex(ca, cb, opt)

--- a/association_test.go
+++ b/association_test.go
@@ -38,9 +38,10 @@ func stressDuplex(t *testing.T) {
 
 	defer stop(t)
 
+	// TODO: Increase once SCTP is more reliable in case of slow reader
 	opt := test.Options{
-		MsgSize:  65535,
-		MsgCount: 1000,
+		MsgSize:  2048, // 65535,
+		MsgCount: 10,   // 1000,
 	}
 
 	err = test.StressDuplex(ca, cb, opt)

--- a/pending_queue_test.go
+++ b/pending_queue_test.go
@@ -6,14 +6,39 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// makePayload() is defined in payload_queue_test.go
+const (
+	noFragment = iota
+	fragBegin
+	fragMiddle
+	fragEnd
+)
+
+func makeDataChunk(tsn uint32, unordered bool, frag int) *chunkPayloadData {
+	var b, e bool
+	switch frag {
+	case noFragment:
+		b = true
+		e = true
+	case fragBegin:
+		b = true
+	case fragEnd:
+		e = true
+	}
+	return &chunkPayloadData{
+		tsn:               tsn,
+		unordered:         unordered,
+		beginningFragment: b,
+		endingFragment:    e,
+		userData:          make([]byte, 10), // always 10 bytes
+	}
+}
 
 func TestPendingBaseQueue(t *testing.T) {
 	t.Run("push and pop", func(t *testing.T) {
 		pq := newPendingBaseQueue()
-		pq.push(makePayload(0, 10))
-		pq.push(makePayload(1, 11))
-		pq.push(makePayload(2, 12))
+		pq.push(makeDataChunk(0, false, noFragment))
+		pq.push(makeDataChunk(1, false, noFragment))
+		pq.push(makeDataChunk(2, false, noFragment))
 
 		for i := uint32(0); i < 3; i++ {
 			c := pq.get(int(i))
@@ -27,8 +52,8 @@ func TestPendingBaseQueue(t *testing.T) {
 			assert.Equal(t, i, c.tsn, "TSN should match")
 		}
 
-		pq.push(makePayload(3, 13))
-		pq.push(makePayload(4, 14))
+		pq.push(makeDataChunk(3, false, noFragment))
+		pq.push(makeDataChunk(4, false, noFragment))
 
 		for i := uint32(3); i < 5; i++ {
 			c := pq.pop()
@@ -42,21 +67,24 @@ func TestPendingBaseQueue(t *testing.T) {
 		assert.Nil(t, pq.pop(), "should be nil")
 		assert.Nil(t, pq.get(0), "should be nil")
 
-		pq.push(makePayload(0, 10))
+		pq.push(makeDataChunk(0, false, noFragment))
 		assert.Nil(t, pq.get(-1), "should be nil")
 		assert.Nil(t, pq.get(1), "should be nil")
 	})
 }
 
 func TestPendingQueue(t *testing.T) {
+	// NOTE: TSN is not used in pendingQueue in the actual usage.
+	//       Following tests use TSN field as a chunk ID.
+
 	t.Run("push and pop", func(t *testing.T) {
 		pq := newPendingQueue()
-		pq.push(makePayload(0, 10))
+		pq.push(makeDataChunk(0, false, noFragment))
 		assert.Equal(t, 10, pq.getNumBytes(), "total bytes mismatch")
-		pq.push(makePayload(1, 11))
-		assert.Equal(t, 21, pq.getNumBytes(), "total bytes mismatch")
-		pq.push(makePayload(2, 12))
-		assert.Equal(t, 33, pq.getNumBytes(), "total bytes mismatch")
+		pq.push(makeDataChunk(1, false, noFragment))
+		assert.Equal(t, 20, pq.getNumBytes(), "total bytes mismatch")
+		pq.push(makeDataChunk(2, false, noFragment))
+		assert.Equal(t, 30, pq.getNumBytes(), "total bytes mismatch")
 
 		for i := uint32(0); i < 3; i++ {
 			c := pq.peek()
@@ -67,10 +95,10 @@ func TestPendingQueue(t *testing.T) {
 
 		assert.Equal(t, 0, pq.getNumBytes(), "total bytes mismatch")
 
-		pq.push(makePayload(3, 13))
-		assert.Equal(t, 13, pq.getNumBytes(), "total bytes mismatch")
-		pq.push(makePayload(4, 14))
-		assert.Equal(t, 27, pq.getNumBytes(), "total bytes mismatch")
+		pq.push(makeDataChunk(3, false, noFragment))
+		assert.Equal(t, 10, pq.getNumBytes(), "total bytes mismatch")
+		pq.push(makeDataChunk(4, false, noFragment))
+		assert.Equal(t, 20, pq.getNumBytes(), "total bytes mismatch")
 
 		for i := uint32(3); i < 5; i++ {
 			c := pq.peek()
@@ -80,5 +108,83 @@ func TestPendingQueue(t *testing.T) {
 		}
 
 		assert.Equal(t, 0, pq.getNumBytes(), "total bytes mismatch")
+	})
+
+	t.Run("unordered wins", func(t *testing.T) {
+		pq := newPendingQueue()
+		pq.push(makeDataChunk(0, false, noFragment))
+		assert.Equal(t, 10, pq.getNumBytes(), "total bytes mismatch")
+		pq.push(makeDataChunk(1, true, noFragment))
+		assert.Equal(t, 20, pq.getNumBytes(), "total bytes mismatch")
+		pq.push(makeDataChunk(2, false, noFragment))
+		assert.Equal(t, 30, pq.getNumBytes(), "total bytes mismatch")
+		pq.push(makeDataChunk(3, true, noFragment))
+		assert.Equal(t, 40, pq.getNumBytes(), "total bytes mismatch")
+
+		c := pq.peek()
+		err := pq.pop(c)
+		assert.NoError(t, err, "should not error")
+		assert.Equal(t, uint32(1), c.tsn, "TSN should match")
+
+		c = pq.peek()
+		err = pq.pop(c)
+		assert.NoError(t, err, "should not error")
+		assert.Equal(t, uint32(3), c.tsn, "TSN should match")
+
+		c = pq.peek()
+		err = pq.pop(c)
+		assert.NoError(t, err, "should not error")
+		assert.Equal(t, uint32(0), c.tsn, "TSN should match")
+
+		c = pq.peek()
+		err = pq.pop(c)
+		assert.NoError(t, err, "should not error")
+		assert.Equal(t, uint32(2), c.tsn, "TSN should match")
+
+		assert.Equal(t, 0, pq.getNumBytes(), "total bytes mismatch")
+	})
+
+	t.Run("fragments", func(t *testing.T) {
+		pq := newPendingQueue()
+		pq.push(makeDataChunk(0, false, fragBegin))
+		pq.push(makeDataChunk(1, false, fragMiddle))
+		pq.push(makeDataChunk(2, false, fragEnd))
+		pq.push(makeDataChunk(3, true, fragBegin))
+		pq.push(makeDataChunk(4, true, fragMiddle))
+		pq.push(makeDataChunk(5, true, fragEnd))
+
+		expects := []uint32{3, 4, 5, 0, 1, 2}
+
+		for _, exp := range expects {
+			c := pq.peek()
+			err := pq.pop(c)
+			assert.NoError(t, err, "should not error")
+			assert.Equal(t, exp, c.tsn, "TSN should match")
+		}
+	})
+
+	// Once decided ordered or unordered, the decision should persist until
+	// it pops a chunk with endingFragment flags set to true.
+	t.Run("selection persistence", func(t *testing.T) {
+		pq := newPendingQueue()
+		pq.push(makeDataChunk(0, false, fragBegin))
+
+		c := pq.peek()
+		err := pq.pop(c)
+		assert.NoError(t, err, "should not error")
+		assert.Equal(t, uint32(0), c.tsn, "TSN should match")
+
+		pq.push(makeDataChunk(1, true, noFragment))
+		pq.push(makeDataChunk(2, false, fragMiddle))
+		pq.push(makeDataChunk(3, false, fragEnd))
+
+		expects := []uint32{2, 3, 1}
+
+		for _, exp := range expects {
+			c = pq.peek()
+			err = pq.pop(c)
+			assert.NoError(t, err, "should not error")
+			assert.Equal(t, exp, c.tsn, "TSN should match")
+		}
 	})
 }

--- a/reassembly_queue.go
+++ b/reassembly_queue.go
@@ -216,15 +216,15 @@ func (r *reassemblyQueue) findCompleteUnorderedChunkSet() *chunkSet {
 	}
 
 	// Extract the range of chunks
-	chunks := r.unorderedChunks[startIdx : startIdx+nChunks]
+	var chunks []*chunkPayloadData
+	chunks = append(chunks, r.unorderedChunks[startIdx:startIdx+nChunks]...)
+
 	r.unorderedChunks = append(
 		r.unorderedChunks[:startIdx],
 		r.unorderedChunks[startIdx+nChunks:]...)
 
 	chunkSet := newChunkSet(0, chunks[0].payloadType)
-	for _, c := range chunks {
-		chunkSet.push(c)
-	}
+	chunkSet.chunks = chunks
 
 	return chunkSet
 }


### PR DESCRIPTION
Resolves #71

* Added a comparison between received data an original data transmitted to vnet_test.go
* Unordered message was found broken
* Potential reorder in the pendingQueue was not happening (which was fixed and unit-tested)
* found **reassmblyQueue had a bug in handling unordered chunk slices**
* fix was confirmed by the test