### PR TITLE
Improve throughput over network with delay

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -1786,7 +1786,7 @@ func TestAssocCongestionControl(t *testing.T) {
 		t.Logf("nT3Timeouts : %d\n", a0.stats.getNumT3Timeouts())
 
 		assert.Equal(t, uint64(nPacketsToSend), a1.stats.getNumDATAs(), "packet count mismatch")
-		assert.True(t, a0.stats.getNumSACKs() < nPacketsToSend/20, "too many sacks")
+		assert.True(t, a0.stats.getNumSACKs() < nPacketsToSend/10, "too many sacks")
 		assert.Equal(t, uint64(0), a0.stats.getNumT3Timeouts(), "should be no retransmit")
 
 		closeAssociationPair(br, a0, a1)

--- a/association_test.go
+++ b/association_test.go
@@ -230,7 +230,7 @@ func (c *dumbConn) SetWriteDeadline(t time.Time) error {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func createNewAssociationPair(br *test.Bridge, ackMode int) (*Association, *Association, error) {
+func createNewAssociationPair(br *test.Bridge, ackMode int, recvBufSize uint32) (*Association, *Association, error) {
 	var a0, a1 *Association
 	var err0, err1 error
 	loggerFactory := logging.NewDefaultLoggerFactory()
@@ -240,15 +240,17 @@ func createNewAssociationPair(br *test.Bridge, ackMode int) (*Association, *Asso
 
 	go func() {
 		a0, err0 = Client(Config{
-			NetConn:       br.GetConn0(),
-			LoggerFactory: loggerFactory,
+			NetConn:              br.GetConn0(),
+			MaxReceiveBufferSize: recvBufSize,
+			LoggerFactory:        loggerFactory,
 		})
 		handshake0Ch <- true
 	}()
 	go func() {
 		a1, err1 = Client(Config{
-			NetConn:       br.GetConn1(),
-			LoggerFactory: loggerFactory,
+			NetConn:              br.GetConn1(),
+			MaxReceiveBufferSize: recvBufSize,
+			LoggerFactory:        loggerFactory,
 		})
 		handshake1Ch <- true
 	}()
@@ -415,7 +417,7 @@ func TestAssocReliable(t *testing.T) {
 		const msg = "ABC"
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -454,7 +456,7 @@ func TestAssocReliable(t *testing.T) {
 		var ppi PayloadProtocolIdentifier
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -508,7 +510,7 @@ func TestAssocReliable(t *testing.T) {
 		var ppi PayloadProtocolIdentifier
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -549,7 +551,7 @@ func TestAssocReliable(t *testing.T) {
 		var ppi PayloadProtocolIdentifier
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -590,7 +592,7 @@ func TestAssocReliable(t *testing.T) {
 		var ppi PayloadProtocolIdentifier
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -649,7 +651,7 @@ func TestAssocReliable(t *testing.T) {
 		var ppi PayloadProtocolIdentifier
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -703,7 +705,7 @@ func TestAssocReliable(t *testing.T) {
 		const msg = "Hello"
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -765,7 +767,7 @@ func TestAssocUnreliable(t *testing.T) {
 		const si uint16 = 1
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -816,7 +818,7 @@ func TestAssocUnreliable(t *testing.T) {
 		const si uint16 = 1
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -869,7 +871,7 @@ func TestAssocUnreliable(t *testing.T) {
 		const si uint16 = 2
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -920,7 +922,7 @@ func TestAssocUnreliable(t *testing.T) {
 		const si uint16 = 1
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -971,7 +973,7 @@ func TestAssocUnreliable(t *testing.T) {
 		const si uint16 = 3
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -1023,7 +1025,7 @@ func TestAssocUnreliable(t *testing.T) {
 		const si uint16 = 3
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -1585,7 +1587,7 @@ func TestAssocT3RtxTimer(t *testing.T) {
 		var ppi PayloadProtocolIdentifier
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -1647,7 +1649,7 @@ func TestAssocCongestionControl(t *testing.T) {
 		var ppi PayloadProtocolIdentifier
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNormal)
+		a0, a1, err := createNewAssociationPair(br, ackModeNormal, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -1709,6 +1711,7 @@ func TestAssocCongestionControl(t *testing.T) {
 	})
 
 	t.Run("Congestion Avoidance", func(t *testing.T) {
+		const maxReceiveBufferSize uint32 = 64 * 1024
 		const si uint16 = 6
 		const nPacketsToSend = 2000
 		var n int
@@ -1718,7 +1721,7 @@ func TestAssocCongestionControl(t *testing.T) {
 
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNormal)
+		a0, a1, err := createNewAssociationPair(br, ackModeNormal, maxReceiveBufferSize)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -1792,6 +1795,7 @@ func TestAssocCongestionControl(t *testing.T) {
 	// This is to test even rwnd becomes 0, sender should be able to send a zero window probe
 	// on T3-rtx retramission timeout to complete receiving all the packets.
 	t.Run("Slow reader", func(t *testing.T) {
+		const maxReceiveBufferSize uint32 = 64 * 1024
 		const si uint16 = 6
 		nPacketsToSend := int(math.Floor(float64(maxReceiveBufferSize)/1000.0)) * 2
 		var n int
@@ -1801,7 +1805,7 @@ func TestAssocCongestionControl(t *testing.T) {
 
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, maxReceiveBufferSize)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -1893,7 +1897,7 @@ func TestAssocDelayedAck(t *testing.T) {
 
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeAlwaysDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeAlwaysDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -1960,7 +1964,7 @@ func TestAssocReset(t *testing.T) {
 		const msg = "ABC"
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}
@@ -2018,7 +2022,7 @@ func TestAssocReset(t *testing.T) {
 		const msg = "ABC"
 		br := test.NewBridge()
 
-		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay)
+		a0, a1, err := createNewAssociationPair(br, ackModeNoDelay, 0)
 		if !assert.Nil(t, err, "failed to create associations") {
 			assert.FailNow(t, "failed due to earlier error")
 		}

--- a/chunk_payload_data.go
+++ b/chunk_payload_data.go
@@ -64,6 +64,10 @@ type chunkPayloadData struct {
 	since     time.Time
 	nSent     uint32 // number of transmission made for this chunk
 	abandoned bool
+
+	// Retransmission flag set when T1-RTX timeout occurred and this
+	// chunk is still in the inflight queue
+	retransmit bool
 }
 
 const (

--- a/payload_queue.go
+++ b/payload_queue.go
@@ -160,6 +160,15 @@ func (q *payloadQueue) getLastTSNReceived() (uint32, bool) {
 	return q.sorted[qlen-1], true
 }
 
+func (q *payloadQueue) markAllToRetrasmit() {
+	for _, c := range q.chunkMap {
+		if c.acked || c.abandoned {
+			continue
+		}
+		c.retransmit = true
+	}
+}
+
 func (q *payloadQueue) getNumBytes() int {
 	return q.nBytes
 }

--- a/payload_queue_test.go
+++ b/payload_queue_test.go
@@ -113,4 +113,23 @@ func TestPayloadQueue(t *testing.T) {
 		assert.True(t, ok, "should be false")
 		assert.Equal(t, uint32(21), tsn, "should match")
 	})
+
+	t.Run("markAllToRetrasmit", func(t *testing.T) {
+		pq := newPayloadQueue()
+		for i := 0; i < 3; i++ {
+			pq.push(makePayload(uint32(i+1), 10), 0)
+		}
+		pq.markAsAcked(2)
+		pq.markAllToRetrasmit()
+
+		c, ok := pq.get(1)
+		assert.True(t, ok, "should be true")
+		assert.True(t, c.retransmit, "should be marked as retransmit")
+		c, ok = pq.get(2)
+		assert.True(t, ok, "should be true")
+		assert.False(t, c.retransmit, "should NOT be marked as retransmit")
+		c, ok = pq.get(3)
+		assert.True(t, ok, "should be true")
+		assert.True(t, c.retransmit, "should be marked as retransmit")
+	})
 }

--- a/vnet_test.go
+++ b/vnet_test.go
@@ -141,6 +141,7 @@ func testRwndFull(t *testing.T, unordered bool) {
 	shutDownClient := make(chan struct{})
 	shutDownServer := make(chan struct{})
 
+	maxReceiveBufferSize := uint32(64 * 1024)
 	msgSize := int(float32(maxReceiveBufferSize)/2) + int(initialMTU)
 	msg := make([]byte, msgSize)
 	rand.Read(msg) // nolint:errcheck,gosec
@@ -159,8 +160,9 @@ func testRwndFull(t *testing.T, unordered bool) {
 
 		// server association
 		assoc, err := Server(Config{
-			NetConn:       conn,
-			LoggerFactory: loggerFactory,
+			NetConn:              conn,
+			MaxReceiveBufferSize: maxReceiveBufferSize,
+			LoggerFactory:        loggerFactory,
 		})
 		if !assert.NoError(t, err, "should succeed") {
 			return
@@ -232,8 +234,9 @@ func testRwndFull(t *testing.T, unordered bool) {
 
 		// client association
 		assoc, err := Client(Config{
-			NetConn:       conn,
-			LoggerFactory: loggerFactory,
+			NetConn:              conn,
+			MaxReceiveBufferSize: maxReceiveBufferSize,
+			LoggerFactory:        loggerFactory,
 		})
 		if !assert.NoError(t, err, "should succeed") {
 			return


### PR DESCRIPTION
Relates to #62

## Changes:
* fix-1: Increase cwnd in slow-start by the current cwnd (to be comparable with TCP), and send immediateAck bit more frequently.
* fix-2: Fix bug with retransmission on t3-rtx timeout (was sending only one by the timeout)
* Increase the initial receive buffer size from 64KB to 1MB (to be comparable with TCP with RTT 160msec)
* Made ReceiveBufferSize configurable (from sctp.Config - defaults to 1MB)
* Add/fix tests.

See the issue #62 for details.