### PR TITLE
Improve handling of SACK

### DIFF
--- a/ack_timer.go
+++ b/ack_timer.go
@@ -43,7 +43,7 @@ func (t *ackTimer) start() bool {
 		return false
 	}
 
-	// this is a noop if the timer is always running
+	// this is a noop if the timer is already running
 	if t.stopFunc != nil {
 		return false
 	}

--- a/chunk_selective_ack.go
+++ b/chunk_selective_ack.go
@@ -129,10 +129,13 @@ func (s *chunkSelectiveAck) check() (abort bool, err error) {
 
 // String makes chunkSelectiveAck printable
 func (s *chunkSelectiveAck) String() string {
-	res := fmt.Sprintf("%s\n%d", s.chunkHeader, s.cumulativeTSNAck)
+	res := fmt.Sprintf("SACK cumTsnAck=%d arwnd=%d dupTsn=%d",
+		s.cumulativeTSNAck,
+		s.advertisedReceiverWindowCredit,
+		s.duplicateTSN)
 
 	for _, gap := range s.gapAckBlocks {
-		res = fmt.Sprintf("\n gap ack: %s", gap)
+		res = fmt.Sprintf("%s\n gap ack: %s", res, gap)
 	}
 
 	return res


### PR DESCRIPTION
Relates to #62

SCTP implementation was not following the suggestion mentioned in RFC 4960 for generating SACK, causing the poor performance in receiving data from others (Browsers, etc)

By generating SACK at every second packet, as suggested by the RFC, improved the performance to close to the theoretical throughput.

See #62 for some benchmarks. 