### PR TITLE
Retransmit RECONFIG

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -1186,10 +1186,12 @@ func TestHandleForwardTSN(t *testing.T) {
 		p := a.handleForwardTSN(fwdtsn)
 
 		a.lock.Lock()
-		ackState := a.ackState
+		delayedAckTriggered := a.delayedAckTriggered
+		immediateAckTriggered := a.immediateAckTriggered
 		a.lock.Unlock()
 		assert.Equal(t, a.peerLastTSN, prevTSN+3, "peerLastTSN should advance by 3 ")
-		assert.Equal(t, ackStateDelay, ackState, "delayed sack should be requested")
+		assert.True(t, delayedAckTriggered, "delayed sack should be triggered")
+		assert.False(t, immediateAckTriggered, "immediate sack should NOT be triggered")
 		assert.Nil(t, p, "should return nil")
 	})
 
@@ -1221,10 +1223,12 @@ func TestHandleForwardTSN(t *testing.T) {
 		p := a.handleForwardTSN(fwdtsn)
 
 		a.lock.Lock()
-		ackState := a.ackState
+		delayedAckTriggered := a.delayedAckTriggered
+		immediateAckTriggered := a.immediateAckTriggered
 		a.lock.Unlock()
 		assert.Equal(t, a.peerLastTSN, prevTSN+2, "peerLastTSN should advance by 3")
-		assert.Equal(t, ackStateDelay, ackState, "delayed sack should be requested")
+		assert.True(t, delayedAckTriggered, "delayed sack should be triggered")
+		assert.False(t, immediateAckTriggered, "immediate sack should NOT be triggered")
 		assert.Nil(t, p, "should return nil")
 	})
 
@@ -1256,10 +1260,10 @@ func TestHandleForwardTSN(t *testing.T) {
 		p := a.handleForwardTSN(fwdtsn)
 
 		a.lock.Lock()
-		ackState := a.ackState
+		immediateAckTriggered := a.immediateAckTriggered
 		a.lock.Unlock()
 		assert.Equal(t, a.peerLastTSN, prevTSN+1, "peerLastTSN should advance by 1")
-		assert.Equal(t, ackStateImmediate, ackState, "immediate sack should be requested")
+		assert.True(t, immediateAckTriggered, "immediate sack should be triggered")
 
 		assert.Nil(t, p, "should return nil")
 	})

--- a/paramheader.go
+++ b/paramheader.go
@@ -2,6 +2,7 @@ package sctp
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -58,5 +59,5 @@ func (p *paramHeader) length() int {
 
 // String makes paramHeader printable
 func (p paramHeader) String() string {
-	return fmt.Sprintf("%s (%d): %s", p.typ, p.len, p.raw)
+	return fmt.Sprintf("%s (%d): %s", p.typ, p.len, hex.Dump(p.raw))
 }

--- a/vnet_test.go
+++ b/vnet_test.go
@@ -509,7 +509,10 @@ func testStreamClose(t *testing.T, dropReconfig bool) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Verify there's no more pending reconfig
-		assert.Equal(t, 0, len(assoc.reconfigs), "should be zero")
+		assoc.lock.RLock()
+		pendingReconfigs := len(assoc.reconfigs)
+		assoc.lock.RUnlock()
+		assert.Equal(t, 0, pendingReconfigs, "should be zero")
 
 		log.Info("client closing")
 	}()


### PR DESCRIPTION
See #45 

In addition to the retransmission of RECONFIG chunk, following bugs were found and also fixed:

* Reconfig was not handled in the case where TSN was forwarded
* The delayed ack handling resolved in #79 for DATA chunk was not applied to ForwardTSN chunk. (I have made a common routine for handleData() and handleForwardTSN())
* Added a test for RECONFIG retransmission
* Refactored a.gatherOutbound() for complexity error by golangci-lint 