### PR TITLE
Support WASM build/test

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package sctp
 
 import (


### PR DESCRIPTION
Some tests using net.Conn connection are disabled for now
as it is not fully supported by WASM MVP stage.

preparation for https://github.com/pion/.goassets/pull/4
