### PR TITLE
Fix data race in TestStats

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -2311,6 +2311,8 @@ func TestStats(t *testing.T) {
 
 	assert.NoError(t, conn.Close())
 
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
 	assert.Equal(t, conn.bytesReceived, a.BytesReceived())
 	assert.Equal(t, conn.bytesSent, a.BytesSent())
 }


### PR DESCRIPTION
Add lock to the stats data read.

Fix  #91