### PR TITLE
Tear down assocation on ABORT chunk

### DIFF
--- a/chunk_abort.go
+++ b/chunk_abort.go
@@ -58,7 +58,17 @@ func (a *chunkAbort) unmarshal(raw []byte) error {
 	return nil
 }
 func (a *chunkAbort) marshal() ([]byte, error) {
-	return nil, errors.Errorf("Unimplemented")
+	a.chunkHeader.typ = ctAbort
+	a.flags = 0x00
+	a.raw = []byte{}
+	for _, ec := range a.errorCauses {
+		raw, err := ec.marshal()
+		if err != nil {
+			return nil, err
+		}
+		a.raw = append(a.raw, raw...)
+	}
+	return a.chunkHeader.marshal()
 }
 
 func (a *chunkAbort) check() (abort bool, err error) {

--- a/chunk_abort_test.go
+++ b/chunk_abort_test.go
@@ -1,0 +1,57 @@
+package sctp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAbortChunk(t *testing.T) {
+	t.Run("One error cause", func(t *testing.T) {
+		abort1 := &chunkAbort{
+			errorCauses: []errorCause{&errorCauseProtocolViolation{
+				errorCauseHeader: errorCauseHeader{code: protocolViolation},
+			}},
+		}
+		bytes, err := abort1.marshal()
+		assert.NoError(t, err, "should succeed")
+
+		abort2 := &chunkAbort{}
+		err = abort2.unmarshal(bytes)
+		assert.NoError(t, err, "should succeed")
+		assert.Equal(t, 1, len(abort2.errorCauses), "should have only one cause")
+		assert.Equal(t,
+			abort1.errorCauses[0].errorCauseCode(),
+			abort2.errorCauses[0].errorCauseCode(),
+			"errorCause code should match")
+	})
+
+	t.Run("Many error causes", func(t *testing.T) {
+		abort1 := &chunkAbort{
+			errorCauses: []errorCause{
+				&errorCauseProtocolViolation{
+					errorCauseHeader: errorCauseHeader{code: invalidMandatoryParameter},
+				},
+				&errorCauseProtocolViolation{
+					errorCauseHeader: errorCauseHeader{code: unrecognizedChunkType},
+				},
+				&errorCauseProtocolViolation{
+					errorCauseHeader: errorCauseHeader{code: protocolViolation},
+				},
+			},
+		}
+		bytes, err := abort1.marshal()
+		assert.NoError(t, err, "should succeed")
+
+		abort2 := &chunkAbort{}
+		err = abort2.unmarshal(bytes)
+		assert.NoError(t, err, "should succeed")
+		assert.Equal(t, 3, len(abort2.errorCauses), "should have only one cause")
+		for i, errorCause := range abort1.errorCauses {
+			assert.Equal(t,
+				errorCause.errorCauseCode(),
+				abort2.errorCauses[i].errorCauseCode(),
+				"errorCause code should match")
+		}
+	})
+}


### PR DESCRIPTION
Properly tear down the association when we receive an ABORT
chunk.