### PR TITLE
Fix ProtocolViolation error from usrsctp and rwnd exhaustion

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -1096,7 +1096,7 @@ func TestCreateForwardTSN(t *testing.T) {
 			streamSequenceNumber: 2,
 			userData:             []byte("ABC"),
 			nSent:                1,
-			abandoned:            true,
+			_abandoned:           true,
 		})
 
 		fwdtsn := a.createForwardTSN()
@@ -1123,7 +1123,7 @@ func TestCreateForwardTSN(t *testing.T) {
 			streamSequenceNumber: 2,
 			userData:             []byte("ABC"),
 			nSent:                1,
-			abandoned:            true,
+			_abandoned:           true,
 		})
 		a.inflightQueue.pushNoCheck(&chunkPayloadData{
 			beginningFragment:    true,
@@ -1133,7 +1133,7 @@ func TestCreateForwardTSN(t *testing.T) {
 			streamSequenceNumber: 3,
 			userData:             []byte("DEF"),
 			nSent:                1,
-			abandoned:            true,
+			_abandoned:           true,
 		})
 		a.inflightQueue.pushNoCheck(&chunkPayloadData{
 			beginningFragment:    true,
@@ -1143,7 +1143,7 @@ func TestCreateForwardTSN(t *testing.T) {
 			streamSequenceNumber: 1,
 			userData:             []byte("123"),
 			nSent:                1,
-			abandoned:            true,
+			_abandoned:           true,
 		})
 
 		fwdtsn := a.createForwardTSN()

--- a/payload_queue.go
+++ b/payload_queue.go
@@ -162,7 +162,7 @@ func (q *payloadQueue) getLastTSNReceived() (uint32, bool) {
 
 func (q *payloadQueue) markAllToRetrasmit() {
 	for _, c := range q.chunkMap {
-		if c.acked || c.abandoned {
+		if c.acked || c.abandoned() {
 			continue
 		}
 		c.retransmit = true

--- a/reassembly_queue.go
+++ b/reassembly_queue.go
@@ -290,51 +290,48 @@ func (r *reassemblyQueue) read(buf []byte) (int, PayloadProtocolIdentifier, erro
 	return nWritten, ppi, err
 }
 
-func (r *reassemblyQueue) forwardTSN(newCumulativeTSN uint32, unordered bool, lastSSN uint16) {
-	if unordered {
-		// This stream is configured to use unordered data. (The given SSN
-		// has no significance)
-		// Remove all fragments in the unordered sets that contains chunks
-		// equal to or older than `newCumulativeTSN`.
-		// We know all sets in the r.unordered are complete ones.
-		// Just remove chunks that are equal to or older than newCumulativeTSN
-		// from the unorderedChunks
-		lastIdx := -1
-		for i, c := range r.unorderedChunks {
-			if sna32GT(c.tsn, newCumulativeTSN) {
-				break
-			}
-			lastIdx = i
-		}
-		if lastIdx >= 0 {
-			for _, c := range r.unorderedChunks[0 : lastIdx+1] {
-				r.subtractNumBytes(len(c.userData))
-			}
-			r.unorderedChunks = r.unorderedChunks[lastIdx+1:]
-		}
-	} else {
-		// This stream is configured to use ordered data.
-		// Use lastSSN to locate a chunkSet then remove it if the set has
-		// not been complete
-		keep := []*chunkSet{}
-		for _, set := range r.ordered {
-			if sna16LTE(set.ssn, lastSSN) {
-				if !set.isComplete() {
-					// drop the set
-					for _, c := range set.chunks {
-						r.subtractNumBytes(len(c.userData))
-					}
-					continue
+func (r *reassemblyQueue) forwardTSNForOrdered(newCumulativeTSN uint32, lastSSN uint16) {
+	// Use lastSSN to locate a chunkSet then remove it if the set has
+	// not been complete
+	keep := []*chunkSet{}
+	for _, set := range r.ordered {
+		if sna16LTE(set.ssn, lastSSN) {
+			if !set.isComplete() {
+				// drop the set
+				for _, c := range set.chunks {
+					r.subtractNumBytes(len(c.userData))
 				}
+				continue
 			}
-			keep = append(keep, set)
 		}
-		r.ordered = keep
+		keep = append(keep, set)
+	}
+	r.ordered = keep
 
-		// Finally, forward nextSSN
-		if sna16LTE(r.nextSSN, lastSSN) {
-			r.nextSSN = lastSSN + 1
+	// Finally, forward nextSSN
+	if sna16LTE(r.nextSSN, lastSSN) {
+		r.nextSSN = lastSSN + 1
+	}
+}
+
+func (r *reassemblyQueue) forwardTSNForUnordered(newCumulativeTSN uint32) {
+	// Remove all fragments in the unordered sets that contains chunks
+	// equal to or older than `newCumulativeTSN`.
+	// We know all sets in the r.unordered are complete ones.
+	// Just remove chunks that are equal to or older than newCumulativeTSN
+	// from the unorderedChunks
+	lastIdx := -1
+	for i, c := range r.unorderedChunks {
+		if sna32GT(c.tsn, newCumulativeTSN) {
+			break
 		}
+		lastIdx = i
+	}
+	if lastIdx >= 0 {
+		for _, c := range r.unorderedChunks[0 : lastIdx+1] {
+			r.subtractNumBytes(len(c.userData))
+		}
+		r.unorderedChunks = r.unorderedChunks[lastIdx+1:]
 	}
 }
 

--- a/reassembly_queue_test.go
+++ b/reassembly_queue_test.go
@@ -400,7 +400,7 @@ func TestReassemblyQueue(t *testing.T) {
 		assert.False(t, complete, "chunk set should not be complete yet")
 		assert.Equal(t, 9, rq.getNumBytes(), "num bytes mismatch")
 
-		rq.forwardTSN(13, false, ssnDropped)
+		rq.forwardTSNForOrdered(13, ssnDropped)
 
 		assert.Equal(t, 1, len(rq.ordered), "there should be one chunk left")
 		assert.Equal(t, 3, rq.getNumBytes(), "num bytes mismatch")
@@ -456,7 +456,7 @@ func TestReassemblyQueue(t *testing.T) {
 
 		// At this point, there are 3 chunks in the rq.unorderedChunks.
 		// This call should remove chunks with tsn equals to 13 or older.
-		rq.forwardTSN(13, true, ssnDropped)
+		rq.forwardTSNForUnordered(13)
 
 		// As a result, there should be one chunk (tsn=14)
 		assert.Equal(t, 1, len(rq.unorderedChunks), "there should be one chunk kept")

--- a/stream.go
+++ b/stream.go
@@ -139,7 +139,6 @@ func (s *Stream) handleForwardTSNForOrdered(newCumulativeTSN uint32, ssn uint16)
 		// the reassemblyQueue.
 		s.reassemblyQueue.forwardTSNForOrdered(newCumulativeTSN, ssn)
 		readable = s.reassemblyQueue.isReadable()
-
 	}()
 
 	// Notify the reader asynchronously if there's a data chunk to read.

--- a/stream.go
+++ b/stream.go
@@ -175,6 +175,7 @@ func (s *Stream) packetize(raw []byte, ppi PayloadProtocolIdentifier) []*chunkPa
 	unordered := ppi != PayloadTypeWebRTCDCEP && s.unordered
 
 	var chunks []*chunkPayloadData
+	var head *chunkPayloadData
 	for remaining != 0 {
 		fragmentSize := min32(s.association.maxPayloadSize, remaining)
 
@@ -192,6 +193,11 @@ func (s *Stream) packetize(raw []byte, ppi PayloadProtocolIdentifier) []*chunkPa
 			immediateSack:        false,
 			payloadType:          ppi,
 			streamSequenceNumber: s.sequenceNumber,
+			head:                 head,
+		}
+
+		if head == nil {
+			head = chunk
 		}
 
 		chunks = append(chunks, chunk)


### PR DESCRIPTION
This PR fixes two issues:
* #104 Abort (ProtocolViolation) with FwdTSN for fragmented messages
* #106  Receive buffer leakage on FwdTSN for unordered data chunks

Test:
* pion/sctp unit tests pass with no race
* Ordered/Unordered data channel test (manual) with Chrome and Firefox

This PR replaces earlier PR #105.