### PR TITLE
Guard shift-left operation

### DIFF
--- a/rtx_timer.go
+++ b/rtx_timer.go
@@ -211,6 +211,9 @@ func calculateNextTimeout(rto float64, nRtos uint) float64 {
 	//        <- RTO * 2 ("back off the timer").  The maximum value discussed
 	//        in rule C7 above (RTO.max) may be used to provide an upper bound
 	//        to this doubling operation.
-	m := 1 << nRtos
-	return math.Min(rto*float64(m), rtoMax)
+	if nRtos < 31 {
+		m := 1 << nRtos
+		return math.Min(rto*float64(m), rtoMax)
+	}
+	return rtoMax
 }

--- a/rtx_timer_test.go
+++ b/rtx_timer_test.go
@@ -54,6 +54,22 @@ func TestRTOManager(t *testing.T) {
 		}
 	})
 
+	t.Run("calculateNextTimeout", func(t *testing.T) {
+		var rto float64
+		rto = calculateNextTimeout(1.0, 0)
+		assert.Equal(t, float64(1), rto, "should match")
+		rto = calculateNextTimeout(1.0, 1)
+		assert.Equal(t, float64(2), rto, "should match")
+		rto = calculateNextTimeout(1.0, 2)
+		assert.Equal(t, float64(4), rto, "should match")
+		rto = calculateNextTimeout(1.0, 30)
+		assert.Equal(t, float64(60000), rto, "should match")
+		rto = calculateNextTimeout(1.0, 63)
+		assert.Equal(t, float64(60000), rto, "should match")
+		rto = calculateNextTimeout(1.0, 64)
+		assert.Equal(t, float64(60000), rto, "should match")
+	})
+
 	t.Run("reset", func(t *testing.T) {
 		m := newRTOManager()
 		for i := 0; i < 10; i++ {


### PR DESCRIPTION
Resolves #109

The guard added allows doing the shift operation up to 30 bits and no more. (maxRTO can be up to 2^30 - large enough).

I added test to verify that next RTO values are capped at maxRTO even nRtos becomes larger than 63.