### PR TITLE
Fix debug log format

### DIFF
--- a/association.go
+++ b/association.go
@@ -431,7 +431,7 @@ func (a *Association) readLoop() {
 		}
 	}
 
-	a.log.Debugf("[%s] readLoop exited %s %s", a.name, closeErr)
+	a.log.Debugf("[%s] readLoop exited %s", a.name, closeErr)
 }
 
 func (a *Association) writeLoop() {


### PR DESCRIPTION
Resolves #112

Fix confirmed:
```
$ PION_LOG_DEBUG=sctp go test -v -run TestRoutineLeak/Close_failed |grep 'readLoop exited'
sctp DEBUG: 13:31:24.243066 association.go:434: [0xc0000b0000] readLoop exited EOF
```
