### PR TITLE
Reset retransmit flag when acked

### DIFF
--- a/payload_queue.go
+++ b/payload_queue.go
@@ -142,6 +142,7 @@ func (q *payloadQueue) markAsAcked(tsn uint32) int {
 	var nBytesAcked int
 	if c, ok := q.chunkMap[tsn]; ok {
 		c.acked = true
+		c.retransmit = false
 		nBytesAcked = len(c.userData)
 		q.nBytes -= nBytesAcked
 		c.userData = []byte{}

--- a/payload_queue_test.go
+++ b/payload_queue_test.go
@@ -132,4 +132,28 @@ func TestPayloadQueue(t *testing.T) {
 		assert.True(t, ok, "should be true")
 		assert.True(t, c.retransmit, "should be marked as retransmit")
 	})
+
+	t.Run("reset retransmit flag on ack", func(t *testing.T) {
+		pq := newPayloadQueue()
+		for i := 0; i < 4; i++ {
+			pq.push(makePayload(uint32(i+1), 10), 0)
+		}
+
+		pq.markAllToRetrasmit()
+		pq.markAsAcked(2) // should cancel retransmission for TSN 2
+		pq.markAsAcked(4) // should cancel retransmission for TSN 4
+
+		c, ok := pq.get(1)
+		assert.True(t, ok, "should be true")
+		assert.True(t, c.retransmit, "should be marked as retransmit")
+		c, ok = pq.get(2)
+		assert.True(t, ok, "should be true")
+		assert.False(t, c.retransmit, "should NOT be marked as retransmit")
+		c, ok = pq.get(3)
+		assert.True(t, ok, "should be true")
+		assert.True(t, c.retransmit, "should be marked as retransmit")
+		c, ok = pq.get(4)
+		assert.True(t, ok, "should be true")
+		assert.False(t, c.retransmit, "should NOT be marked as retransmit")
+	})
 }


### PR DESCRIPTION
Resolves #104

> Sorry... typo in the branch name... this is for issue 104.

Please read #104 for details.

When T3-rtx timeout occurs, it sets `retransmit` flag of all chunks in the inflightQueue to true. Immediately after that  (before the actual retransmission takes place by the writeLoop go-routne), SACK was received for some of these data chunks and their `acked` flag was set to true and userData was deleted (empty) without resetting `retransmit` flag. This ended up with sending DATA chunk with userData field being empty, causing the remote to send Abort chunk because sending DATA chunks with zero-length userData field is illegal according to RFC.

This branch reset the `retransmit` flag when SACK is received for a DATA chunk. I no longer see Abort coming back.