### PR TITLE
Reduce allocations in association.readLoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [Lukas Herman](https://github.com/lherman-cs)
 * [Luke Curley](https://github.com/kixelated) - *Performance*
+* [Aaron France](https://github.com/AeroNotix)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
#### Description

* In my local testing reads from the underlying SCTP stream are rarely (if ever!)
sized at the receiveMTU amount.
* Typically they are around 30-700 bytes.
* This reduces the memory allocations by a fair whack.

May need more thorough testing.
