### PR TITLE
Set default MaxMessageSize to 65536

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -179,7 +179,8 @@ func (s *Stream) Write(p []byte) (n int, err error) {
 
 // WriteSCTP writes len(p) bytes from p to the DTLS connection
 func (s *Stream) WriteSCTP(p []byte, ppi PayloadProtocolIdentifier) (n int, err error) {
-	if len(p) > math.MaxUint16 {
+	maxMessageSize := s.association.MaxMessageSize()
+	if len(p) > int(maxMessageSize) {
 		return 0, errors.Errorf("Outbound packet larger than maximum message size %v", math.MaxUint16)
 	}
 


### PR DESCRIPTION
## Changes
* Modified the default maxMessageSize from 65535 to 65536.
* Added getter/setter function also.

Relates to pion/webrtc#1396
