### PR TITLE
Implement shutdown sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Aaron France](https://github.com/AeroNotix)
 * [ZHENK](https://github.com/scorpionknifes)
 * [Teddy](https://github.com/rgeorgeoff)
+* [Jerko Steiner](https://github.com/jeremija)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/chunk_shutdown.go
+++ b/chunk_shutdown.go
@@ -1,0 +1,68 @@
+package sctp
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+/*
+chunkShutdown represents an SCTP Chunk of type chunkShutdown
+
+0                   1                   2                   3
+0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|   Type = 7    | Chunk  Flags  |      Length = 8               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                      Cumulative TSN Ack                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+*/
+type chunkShutdown struct {
+	chunkHeader
+	cumulativeTSNAck uint32
+}
+
+const (
+	cumulativeTSNAckLength = 4
+)
+
+var (
+	errInvalidChunkSize     = errors.New("invalid chunk size")
+	errChunkTypeNotShutdown = errors.New("ChunkType is not of type SHUTDOWN")
+)
+
+func (c *chunkShutdown) unmarshal(raw []byte) error {
+	if err := c.chunkHeader.unmarshal(raw); err != nil {
+		return err
+	}
+
+	if c.typ != ctShutdown {
+		return fmt.Errorf("%w: actually is %s", errChunkTypeNotShutdown, c.typ.String())
+	}
+
+	if len(c.raw) != cumulativeTSNAckLength {
+		return errInvalidChunkSize
+	}
+
+	c.cumulativeTSNAck = binary.BigEndian.Uint32(c.raw[0:])
+
+	return nil
+}
+
+func (c *chunkShutdown) marshal() ([]byte, error) {
+	out := make([]byte, cumulativeTSNAckLength)
+	binary.BigEndian.PutUint32(out[0:], c.cumulativeTSNAck)
+
+	c.typ = ctShutdown
+	c.raw = out
+	return c.chunkHeader.marshal()
+}
+
+func (c *chunkShutdown) check() (abort bool, err error) {
+	return false, nil
+}
+
+// String makes chunkShutdown printable
+func (c *chunkShutdown) String() string {
+	return c.chunkHeader.String()
+}

--- a/chunk_shutdown_ack.go
+++ b/chunk_shutdown_ack.go
@@ -1,0 +1,47 @@
+package sctp
+
+import (
+	"errors"
+	"fmt"
+)
+
+/*
+chunkShutdownAck represents an SCTP Chunk of type chunkShutdownAck
+
+0                   1                   2                   3
+0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|   Type = 8    | Chunk  Flags  |      Length = 4               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+*/
+type chunkShutdownAck struct {
+	chunkHeader
+}
+
+var errChunkTypeNotShutdownAck = errors.New("ChunkType is not of type SHUTDOWN-ACK")
+
+func (c *chunkShutdownAck) unmarshal(raw []byte) error {
+	if err := c.chunkHeader.unmarshal(raw); err != nil {
+		return err
+	}
+
+	if c.typ != ctShutdownAck {
+		return fmt.Errorf("%w: actually is %s", errChunkTypeNotShutdownAck, c.typ.String())
+	}
+
+	return nil
+}
+
+func (c *chunkShutdownAck) marshal() ([]byte, error) {
+	c.typ = ctShutdownAck
+	return c.chunkHeader.marshal()
+}
+
+func (c *chunkShutdownAck) check() (abort bool, err error) {
+	return false, nil
+}
+
+// String makes chunkShutdownAck printable
+func (c *chunkShutdownAck) String() string {
+	return c.chunkHeader.String()
+}

--- a/chunk_shutdown_ack_test.go
+++ b/chunk_shutdown_ack_test.go
@@ -1,0 +1,45 @@
+package sctp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChunkShutdownAck_Success(t *testing.T) {
+	tt := []struct {
+		binary []byte
+	}{
+		{[]byte{0x08, 0x00, 0x00, 0x04}},
+	}
+
+	for i, tc := range tt {
+		actual := &chunkShutdownAck{}
+		err := actual.unmarshal(tc.binary)
+		require.NoError(t, err, "failed to unmarshal #%d: %v", i, err)
+
+		b, err := actual.marshal()
+		require.NoError(t, err, "failed to marshal: %v", err)
+		assert.Equal(t, tc.binary, b, "test %d not equal", i)
+	}
+}
+
+func TestChunkShutdownAck_Failure(t *testing.T) {
+	tt := []struct {
+		name   string
+		binary []byte
+	}{
+		{"length too short", []byte{0x08, 0x00, 0x00}},
+		{"length too long", []byte{0x08, 0x00, 0x00, 0x04, 0x12}},
+		{"invalid type", []byte{0x0f, 0x00, 0x00, 0x04}},
+	}
+
+	for i, tc := range tt {
+		actual := &chunkShutdownAck{}
+		err := actual.unmarshal(tc.binary)
+		if err == nil {
+			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
+		}
+	}
+}

--- a/chunk_shutdown_complete.go
+++ b/chunk_shutdown_complete.go
@@ -1,0 +1,47 @@
+package sctp
+
+import (
+	"errors"
+	"fmt"
+)
+
+/*
+chunkShutdownComplete represents an SCTP Chunk of type chunkShutdownComplete
+
+0                   1                   2                   3
+0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|   Type = 14   |Reserved     |T|      Length = 4               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+*/
+type chunkShutdownComplete struct {
+	chunkHeader
+}
+
+var errChunkTypeNotShutdownComplete = errors.New("ChunkType is not of type SHUTDOWN-COMPLETE")
+
+func (c *chunkShutdownComplete) unmarshal(raw []byte) error {
+	if err := c.chunkHeader.unmarshal(raw); err != nil {
+		return err
+	}
+
+	if c.typ != ctShutdownComplete {
+		return fmt.Errorf("%w: actually is %s", errChunkTypeNotShutdownComplete, c.typ.String())
+	}
+
+	return nil
+}
+
+func (c *chunkShutdownComplete) marshal() ([]byte, error) {
+	c.typ = ctShutdownComplete
+	return c.chunkHeader.marshal()
+}
+
+func (c *chunkShutdownComplete) check() (abort bool, err error) {
+	return false, nil
+}
+
+// String makes chunkShutdownComplete printable
+func (c *chunkShutdownComplete) String() string {
+	return c.chunkHeader.String()
+}

--- a/chunk_shutdown_complete_test.go
+++ b/chunk_shutdown_complete_test.go
@@ -1,0 +1,43 @@
+package sctp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChunkShutdownComplete_Success(t *testing.T) {
+	tt := []struct {
+		binary []byte
+	}{
+		{[]byte{0x0e, 0x00, 0x00, 0x04}},
+	}
+
+	for i, tc := range tt {
+		actual := &chunkShutdownComplete{}
+		err := actual.unmarshal(tc.binary)
+		require.NoError(t, err, "failed to unmarshal #%d: %v", i, err)
+
+		b, err := actual.marshal()
+		require.NoError(t, err, "failed to marshal: %v", err)
+		assert.Equal(t, tc.binary, b, "test %d not equal", i)
+	}
+}
+
+func TestChunkShutdownComplete_Failure(t *testing.T) {
+	tt := []struct {
+		name   string
+		binary []byte
+	}{
+		{"length too short", []byte{0x0e, 0x00, 0x00}},
+		{"length too long", []byte{0x0e, 0x00, 0x00, 0x04, 0x12}},
+		{"invalid type", []byte{0x0f, 0x00, 0x00, 0x04}},
+	}
+
+	for i, tc := range tt {
+		actual := &chunkShutdownComplete{}
+		err := actual.unmarshal(tc.binary)
+		require.Error(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
+	}
+}

--- a/chunk_shutdown_test.go
+++ b/chunk_shutdown_test.go
@@ -1,0 +1,50 @@
+package sctp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChunkShutdown_Success(t *testing.T) {
+	tt := []struct {
+		binary []byte
+	}{
+		{[]byte{0x07, 0x00, 0x00, 0x08, 0x12, 0x34, 0x56, 0x78}},
+	}
+
+	for i, tc := range tt {
+		actual := &chunkShutdown{}
+		err := actual.unmarshal(tc.binary)
+		if err != nil {
+			t.Fatalf("failed to unmarshal #%d: %v", i, err)
+		}
+
+		b, err := actual.marshal()
+		if err != nil {
+			t.Fatalf("failed to marshal: %v", err)
+		}
+		assert.Equal(t, tc.binary, b, "test %d not equal", i)
+	}
+}
+
+func TestChunkShutdown_Failure(t *testing.T) {
+	tt := []struct {
+		name   string
+		binary []byte
+	}{
+		{"length too short", []byte{0x07, 0x00, 0x00, 0x07, 0x12, 0x34, 0x56, 0x78}},
+		{"length too long", []byte{0x07, 0x00, 0x00, 0x09, 0x12, 0x34, 0x56, 0x78}},
+		{"payload too short", []byte{0x07, 0x00, 0x00, 0x08, 0x12, 0x34, 0x56}},
+		{"payload too long", []byte{0x07, 0x00, 0x00, 0x08, 0x12, 0x34, 0x56, 0x78, 0x9f}},
+		{"invalid type", []byte{0x08, 0x00, 0x00, 0x08, 0x12, 0x34, 0x56, 0x78}},
+	}
+
+	for i, tc := range tt {
+		actual := &chunkShutdown{}
+		err := actual.unmarshal(tc.binary)
+		if err == nil {
+			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
+		}
+	}
+}

--- a/packet.go
+++ b/packet.go
@@ -108,6 +108,12 @@ func (p *packet) unmarshal(raw []byte) error {
 			c = &chunkForwardTSN{}
 		case ctError:
 			c = &chunkError{}
+		case ctShutdown:
+			c = &chunkShutdown{}
+		case ctShutdownAck:
+			c = &chunkShutdownAck{}
+		case ctShutdownComplete:
+			c = &chunkShutdownComplete{}
 		default:
 			return fmt.Errorf("%w: %s", errUnmarshalUnknownChunkType, chunkType(raw[offset]).String())
 		}

--- a/stream.go
+++ b/stream.go
@@ -190,6 +190,16 @@ func (s *Stream) WriteSCTP(p []byte, ppi PayloadProtocolIdentifier) (n int, err 
 		return 0, fmt.Errorf("%w: %v", errOutboundPacketTooLarge, math.MaxUint16)
 	}
 
+	switch s.association.getState() {
+	case shutdownSent, shutdownAckSent, shutdownPending, shutdownReceived:
+		s.lock.Lock()
+		if s.writeErr == nil {
+			s.writeErr = errStreamClosed
+		}
+		s.lock.Unlock()
+	default:
+	}
+
 	s.lock.RLock()
 	err = s.writeErr
 	s.lock.RUnlock()


### PR DESCRIPTION
#### Description
I finally had some time to continue the work on adding the multi server node support on `Peer Calls`. I noticed there was an issue where the other side did not notice that a SCTP association was closed from the other side.

I tried to follow the steps from the [`SCTP Association State Diagram`][1] and [`Shutdown of an Association`][2] sections of [RFC 4960][3].

I added two new tests and all existing tests passed.

Instead of modifying the existing `Close` function I added a new `Shutdown` method to keep the backwards compatibility. I also thought it made sense to allow the users to pick which teardown strategy to use.

Perhaps the `Close` should be modified to use `Abort`?

#### Reference issue
Fixes #152.

[1]: https://tools.ietf.org/html/rfc4960#section-4
[2]: https://tools.ietf.org/html/rfc4960#section-9.2
[3]: https://tools.ietf.org/html/rfc4960