### PR TITLE
Fix packet handling before init

### DIFF
--- a/association.go
+++ b/association.go
@@ -1146,6 +1146,11 @@ func (a *Association) handleHeartbeat(c *chunkHeartbeat) []*packet {
 func (a *Association) handleCookieEcho(c *chunkCookieEcho) []*packet {
 	state := a.getState()
 	a.log.Debugf("[%s] COOKIE-ECHO received in state '%s'", a.name, getAssociationStateString(state))
+
+	if a.myCookie == nil {
+		a.log.Debugf("[%s] COOKIE-ECHO received before initialization", a.name)
+		return nil
+	}
 	switch state {
 	default:
 		return nil

--- a/chunk_payload_data.go
+++ b/chunk_payload_data.go
@@ -2,6 +2,7 @@ package sctp
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -95,6 +96,8 @@ const (
 	PayloadTypeWebRTCBinaryEmpty PayloadProtocolIdentifier = 57
 )
 
+var errChunkPayloadSmall = errors.New("packet is smaller than the header size")
+
 func (p PayloadProtocolIdentifier) String() string {
 	switch p {
 	case PayloadTypeWebRTCDCEP:
@@ -122,6 +125,9 @@ func (p *chunkPayloadData) unmarshal(raw []byte) error {
 	p.beginningFragment = p.flags&payloadDataBeginingFragmentBitmask != 0
 	p.endingFragment = p.flags&payloadDataEndingFragmentBitmask != 0
 
+	if len(raw) < payloadDataHeaderSize {
+		return errChunkPayloadSmall
+	}
 	p.tsn = binary.BigEndian.Uint32(p.raw[0:])
 	p.streamIdentifier = binary.BigEndian.Uint16(p.raw[4:])
 	p.streamSequenceNumber = binary.BigEndian.Uint16(p.raw[6:])


### PR DESCRIPTION
It caused panic when some kind of packets are arrived before completing initialization.
Add error check to CookieEcho and Data handlers.

### Reference issue
Fixes #188 