### PR TITLE
Add more functionality for SCTPTransportStats

### DIFF
--- a/association.go
+++ b/association.go
@@ -984,7 +984,7 @@ func (a *Association) UNACKData() uint32 {
 	return atomic.LoadUint32(&a.rwnd)
 }
 */
-// Get latest Smoothed Round Trip Time for smoothedRoundTripTime in SCTPTransportStats
+// SRTT returns the latest smoothedRoundTripTime
 func (a *Association) SRTT() float64 {
 	return a.srtt.Load().(float64)
 }

--- a/association_test.go
+++ b/association_test.go
@@ -2236,6 +2236,10 @@ type fakeEchoConn struct {
 
 	bytesSent     uint64
 	bytesReceived uint64
+	mtu           uint32
+	cwnd          uint32
+	rwnd          uint32
+	srtt          float64
 }
 
 func newFakeEchoConn(errClose error) *fakeEchoConn {
@@ -2358,6 +2362,10 @@ func TestStats(t *testing.T) {
 	defer conn.mu.Unlock()
 	assert.Equal(t, conn.bytesReceived, a.BytesReceived())
 	assert.Equal(t, conn.bytesSent, a.BytesSent())
+	assert.Equal(t, conn.mtu, a.MTU())
+	assert.Equal(t, conn.cwnd, a.CWND())
+	assert.Equal(t, conn.rwnd, a.RWND())
+	assert.Equal(t, conn.srtt, a.SRTT())
 }
 
 func TestAssocHandleInit(t *testing.T) {


### PR DESCRIPTION
#### Description
Adds functions to get the stats required in  https://www.w3.org/TR/webrtc-stats/#sctptransportstats-dict*

Also is there a way to get the amount of unacked data right now? I couldn't find a function/ parameter for it yet
