### PR TITLE
sctp.Client guarantees its own streams map has OpenStreams

### DIFF
--- a/association.go
+++ b/association.go
@@ -248,9 +248,13 @@ func Server(config Config) (*Association, error) {
 }
 
 // Client opens a SCTP stream over a conn
-func Client(config Config) (*Association, error) {
+func Client(config Config, streamIdentifiers ...uint16) (*Association, error) {
 	a := createAssociation(config)
 	a.init(true)
+
+	for _, s := range streamIdentifiers {
+		_, _ = a.OpenStream(s, PayloadTypeWebRTCBinary)
+	}
 
 	select {
 	case err := <-a.handshakeCompletedCh:


### PR DESCRIPTION
#### Description

once association.readLoop goroutine runs, It can be exited by
any reason. When readLoop is done, defer calls
unregisterStream which send signal Stream's sync.Cond var.
If readLoop is done before association.OpenStream is called,
Stream.ReadSCTP's sync.Cond wait for signal infinitely
because association.streams doesn't have any stream yet.

this is for https://github.com/pion/webrtc/issues/2098

#### Reference issue
Fixes #...
