### PR TITLE
Fix OpenStream return a closed stream

### DIFF
--- a/association.go
+++ b/association.go
@@ -1393,7 +1393,7 @@ func (a *Association) createStream(streamIdentifier uint16, accept bool) *Stream
 
 // getOrCreateStream gets or creates a stream. The caller should hold the lock.
 func (a *Association) getOrCreateStream(streamIdentifier uint16, accept bool, defaultPayloadType PayloadProtocolIdentifier) *Stream {
-	if s, ok := a.streams[streamIdentifier]; ok {
+	if s, ok := a.streams[streamIdentifier]; ok && s.writeErr != errStreamClosed {
 		s.SetDefaultPayloadType(defaultPayloadType)
 		return s
 	}


### PR DESCRIPTION
#### Description
i want to reuse StreamIdentifier after the parent dc closed, but the current code will return a broken datachannel with a closed stream
```go
package main

import (
	"fmt"
	"time"

	"github.com/lainio/err2/try"
	"github.com/pion/webrtc/v3"
)

func main2() {

	var api *webrtc.API
	var pc *webrtc.PeerConnection
	defer pc.Close()

	var id uint16 = 0
	for {
		go func() {
			// id++
			params := &webrtc.DataChannelParameters{
				ID: &id,
			}
			dc := try.To1(
				api.NewDataChannel(pc.SCTP(), params))
			defer dc.Close()
			conn := try.To1(
				dc.Detach())

			fmt.Fprintln(conn, "woooooooooo")

			for {
				n := dc.BufferedAmount()
				if n == 0 {
					break
				}
			}
		}()
		time.Sleep(3 * time.Second)
	}
}
```

#### Reference issue
Fixes #...
