### PR TITLE
Fix race in TestStreamClose introduced by #238

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -12,6 +12,7 @@ chenkaiC4 <chenkaic4@gmail.com>
 Hugo Arregui <hugo.arregui@gmail.com>
 Hugo Arregui <hugo@decentraland.org>
 Jerko Steiner <jerko.steiner@gmail.com>
+Jerry Tao <taojay315@gmail.com>
 John Bradley <jrb@turrettech.com>
 Konstantin Itskov <konstantin.itskov@kovits.com>
 Lukas Herman <lherman.cs@gmail.com>

--- a/vnet_test.go
+++ b/vnet_test.go
@@ -463,8 +463,8 @@ func TestStreamClose(t *testing.T) {
 				log.Infof("server: received %d bytes (%d)", n, numServerReceived)
 				assert.Equal(t, 0, bytes.Compare(buf[:n], messages[numServerReceived]), "should receive HELLO")
 
-				_, err = stream.Write(buf[:n])
-				assert.NoError(t, err, "should succeed")
+				_, err2 := stream.Write(buf[:n])
+				assert.NoError(t, err2, "should succeed")
 
 				numServerReceived++
 			}


### PR DESCRIPTION
Fixes #242

Renaming an error object in a goroutine in TestStreamClose to avoid race error during test.
Occurrence ratio: ~ 1/5