### PR TITLE
Send enqueued chunks when in closing state

### DIFF
--- a/association.go
+++ b/association.go
@@ -124,12 +124,13 @@ func getAssociationStateString(a uint32) string {
 //
 // Tag         :
 // State       : A state variable indicating what state the association
-//             : is in, i.e., COOKIE-WAIT, COOKIE-ECHOED, ESTABLISHED,
-//             : SHUTDOWN-PENDING, SHUTDOWN-SENT, SHUTDOWN-RECEIVED,
-//             : SHUTDOWN-ACK-SENT.
 //
-//               Note: No "CLOSED" state is illustrated since if a
-//               association is "CLOSED" its TCB SHOULD be removed.
+//	: is in, i.e., COOKIE-WAIT, COOKIE-ECHOED, ESTABLISHED,
+//	: SHUTDOWN-PENDING, SHUTDOWN-SENT, SHUTDOWN-RECEIVED,
+//	: SHUTDOWN-ACK-SENT.
+//
+//	  Note: No "CLOSED" state is illustrated since if a
+//	  association is "CLOSED" its TCB SHOULD be removed.
 type Association struct {
 	bytesReceived uint64
 	bytesSent     uint64
@@ -221,9 +222,8 @@ type Association struct {
 	delayedAckTriggered   bool
 	immediateAckTriggered bool
 
-	name          string
-	log           logging.LeveledLogger
-	streamVersion uint32
+	name string
+	log  logging.LeveledLogger
 }
 
 // Config collects the arguments to createAssociation construction into
@@ -1369,7 +1369,6 @@ func (a *Association) createStream(streamIdentifier uint16, accept bool) *Stream
 		streamIdentifier: streamIdentifier,
 		reassemblyQueue:  newReassemblyQueue(streamIdentifier),
 		log:              a.log,
-		version:          atomic.AddUint32(&a.streamVersion, 1),
 		name:             fmt.Sprintf("%d:%s", streamIdentifier, a.name),
 	}
 
@@ -2070,7 +2069,7 @@ func (a *Association) movePendingDataChunkToInflightQueue(c *chunkPayloadData) {
 // The caller should hold the lock.
 func (a *Association) popPendingDataChunksToSend() ([]*chunkPayloadData, []uint16) {
 	chunks := []*chunkPayloadData{}
-	var sisToReset []uint16 // stream identifieres to reset
+	var sisToReset []uint16 // stream identifiers to reset
 
 	if a.pendingQueue.size() > 0 {
 		// RFC 4960 sec 6.1.  Transmission of DATA Chunks
@@ -2096,7 +2095,7 @@ func (a *Association) popPendingDataChunksToSend() ([]*chunkPayloadData, []uint1
 
 			s, ok := a.streams[c.streamIdentifier]
 
-			if !ok || s.State() > StreamStateOpen || s.version != c.streamVersion {
+			if !ok || s.State() == StreamStateClosed {
 				a.popPendingDataChunksToDrop(c)
 				continue
 			}

--- a/chunk_payload_data.go
+++ b/chunk_payload_data.go
@@ -10,8 +10,9 @@ import (
 /*
 chunkPayloadData represents an SCTP Chunk of type DATA
 
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	0                   1                   2                   3
+	0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |   Type = 0    | Reserved|U|B|E|    Length                     |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -26,11 +27,12 @@ chunkPayloadData represents an SCTP Chunk of type DATA
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-
 An unfragmented user message shall have both the B and E bits set to
 '1'.  Setting both B and E bits to '0' indicates a middle fragment of
 a multi-fragment user message, as summarized in the following table:
-   B E                  Description
+
+	B E                  Description
+
 ============================================================
 |  1 0 | First piece of a fragmented user message          |
 +----------------------------------------------------------+
@@ -71,8 +73,7 @@ type chunkPayloadData struct {
 	// chunk is still in the inflight queue
 	retransmit bool
 
-	head          *chunkPayloadData // link to the head of the fragment
-	streamVersion uint32
+	head *chunkPayloadData // link to the head of the fragment
 }
 
 const (

--- a/stream.go
+++ b/stream.go
@@ -71,7 +71,6 @@ type Stream struct {
 	state               StreamState
 	log                 logging.LeveledLogger
 	name                string
-	version             uint32
 }
 
 // StreamIdentifier returns the Stream identifier associated to the stream.
@@ -297,7 +296,6 @@ func (s *Stream) packetize(raw []byte, ppi PayloadProtocolIdentifier) []*chunkPa
 		copy(userData, raw[i:i+fragmentSize])
 
 		chunk := &chunkPayloadData{
-			streamVersion:        s.version,
 			streamIdentifier:     s.streamIdentifier,
 			userData:             userData,
 			unordered:            unordered,
@@ -345,7 +343,7 @@ func (s *Stream) Close() error {
 
 		switch state {
 		case StreamStateOpen:
-			s.SetState(StreamStateClosed)
+			s.SetState(StreamStateClosing)
 			s.log.Debugf("[%s] state change: open => closed", s.name)
 			s.readErr = io.EOF
 			s.readNotifier.Broadcast()


### PR DESCRIPTION
This slightly scales back the work done in https://github.com/pion/sctp/pull/245 which appears to have caused a regression in what https://github.com/pion/webrtc appears to expect in terms of data channel closing behavior with respect to pending writes on the sender side. More specifically, `TestEOF/Detach` started to fail where we expected that when the sender did a write followed by close, that the reader would see those writes and then see an EOF.

@enobufs, to be honest, I'm not 100% sure if the original PR was correct or if I'm even correct here. The change I made here is to still follow [RFC6525](https://www.rfc-editor.org/rfc/rfc6525#section-5.1) for outgoing resets where we wait to send queued reads.