### PR TITLE
Revert "Remove pending buffer when stream closed"

### DIFF
--- a/chunk_payload_data.go
+++ b/chunk_payload_data.go
@@ -71,8 +71,7 @@ type chunkPayloadData struct {
 	// chunk is still in the inflight queue
 	retransmit bool
 
-	head          *chunkPayloadData // link to the head of the fragment
-	streamVersion uint32
+	head *chunkPayloadData // link to the head of the fragment
 }
 
 const (

--- a/vnet_test.go
+++ b/vnet_test.go
@@ -1,6 +1,7 @@
 package sctp
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"net"
@@ -386,84 +387,91 @@ func TestRwndFull(t *testing.T) {
 }
 
 func TestStreamClose(t *testing.T) {
-	lim := test.TimeOut(time.Second * 10)
-	defer lim.Stop()
+	loopBackTest := func(t *testing.T, dropReconfigChunk bool) {
+		lim := test.TimeOut(time.Second * 10)
+		defer lim.Stop()
 
-	loggerFactory := logging.NewDefaultLoggerFactory()
-	log := loggerFactory.NewLogger("test")
+		loggerFactory := logging.NewDefaultLoggerFactory()
+		log := loggerFactory.NewLogger("test")
 
-	venv, err := buildVNetEnv(&vNetEnvConfig{
-		loggerFactory: loggerFactory,
-		log:           log,
-	})
-	if !assert.NoError(t, err, "should succeed") {
-		return
-	}
-	if !assert.NotNil(t, venv, "should not be nil") {
-		return
-	}
-	defer venv.wan.Stop() // nolint:errcheck
-
-	serverStreamReady := make(chan struct{})
-	clientStreamReady := make(chan struct{})
-	clientStartClose := make(chan struct{})
-	serverStreamClosed := make(chan struct{})
-	shutDownClient := make(chan struct{})
-	clientShutDown := make(chan struct{})
-	serverShutDown := make(chan struct{})
-
-	go func() {
-		defer close(serverShutDown)
-		// connected UDP conn for server
-		conn, err := venv.net0.DialUDP("udp4",
-			&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5000},
-			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5000},
-		)
-		if !assert.NoError(t, err, "should succeed") {
-			return
-		}
-		defer conn.Close() // nolint:errcheck
-
-		// server association
-		assoc, err := Server(Config{
-			NetConn:       conn,
-			LoggerFactory: loggerFactory,
+		venv, err := buildVNetEnv(&vNetEnvConfig{
+			loggerFactory: loggerFactory,
+			log:           log,
 		})
 		if !assert.NoError(t, err, "should succeed") {
 			return
 		}
-		defer assoc.Close() // nolint:errcheck
-
-		log.Info("server handshake complete")
-
-		stream, err := assoc.AcceptStream()
-		if !assert.NoError(t, err, "should succeed") {
+		if !assert.NotNil(t, venv, "should not be nil") {
 			return
 		}
-		defer stream.Close() // nolint:errcheck
+		defer venv.wan.Stop() // nolint:errcheck
 
-		buf := make([]byte, 1500)
-		for {
-			n, err := stream.Read(buf)
-			if err != nil {
-				t.Logf("server: Read returned %v", err)
-				break
-			}
+		clientShutDown := make(chan struct{})
+		serverShutDown := make(chan struct{})
 
-			if !assert.Equal(t, "HELLO", string(buf[:n]), "should receive HELLO") {
-				continue
-			}
+		const numMessages = 10
+		const messageSize = 1024
+		var messages [][]byte
+		var numServerReceived int
+		var numClientReceived int
 
-			log.Info("server stream ready")
-			close(serverStreamReady)
+		for i := 0; i < numMessages; i++ {
+			bytes := make([]byte, messageSize)
+			messages = append(messages, bytes)
 		}
 
-		close(serverStreamClosed)
-		log.Info("server closing")
-	}()
+		go func() {
+			defer close(serverShutDown)
+			// connected UDP conn for server
+			conn, innerErr := venv.net0.DialUDP("udp4",
+				&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5000},
+				&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5000},
+			)
+			if !assert.NoError(t, innerErr, "should succeed") {
+				return
+			}
+			defer conn.Close() // nolint:errcheck
 
-	go func() {
-		defer close(clientShutDown)
+			// server association
+			assoc, innerErr := Server(Config{
+				NetConn:       conn,
+				LoggerFactory: loggerFactory,
+			})
+			if !assert.NoError(t, innerErr, "should succeed") {
+				return
+			}
+			defer assoc.Close() // nolint:errcheck
+
+			log.Info("server handshake complete")
+
+			stream, innerErr := assoc.AcceptStream()
+			if !assert.NoError(t, innerErr, "should succeed") {
+				return
+			}
+			assert.Equal(t, StreamStateOpen, stream.State())
+
+			buf := make([]byte, 1500)
+			for {
+				n, errRead := stream.Read(buf)
+				if errRead != nil {
+					log.Infof("server: Read returned %v", errRead)
+					_ = stream.Close() // nolint:errcheck
+					assert.Equal(t, StreamStateClosed, stream.State())
+					break
+				}
+
+				log.Infof("server: received %d bytes (%d)", n, numServerReceived)
+				assert.Equal(t, 0, bytes.Compare(buf[:n], messages[numServerReceived]), "should receive HELLO")
+
+				_, err2 := stream.Write(buf[:n])
+				assert.NoError(t, err2, "should succeed")
+
+				numServerReceived++
+			}
+			// don't close association until the client's stream routine is complete
+			<-clientShutDown
+		}()
+
 		// connected UDP conn for client
 		conn, err := venv.net1.DialUDP("udp4",
 			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5000},
@@ -472,6 +480,7 @@ func TestStreamClose(t *testing.T) {
 		if !assert.NoError(t, err, "should succeed") {
 			return
 		}
+		defer conn.Close() // nolint:errcheck
 
 		// client association
 		assoc, err := Client(Config{
@@ -489,45 +498,51 @@ func TestStreamClose(t *testing.T) {
 		if !assert.NoError(t, err, "should succeed") {
 			return
 		}
-
+		assert.Equal(t, StreamStateOpen, stream.State())
 		stream.SetReliabilityParams(false, ReliabilityTypeReliable, 0)
 
-		// Send a message to let server side stream to open
-		_, err = stream.Write([]byte("HELLO"))
-		if !assert.NoError(t, err, "should succeed") {
-			return
-		}
-
+		// begin client read-loop
 		buf := make([]byte, 1500)
-		done := make(chan struct{})
 		go func() {
+			defer close(clientShutDown)
 			for {
-				log.Info("client read")
-				_, err2 := stream.Read(buf)
+				n, err2 := stream.Read(buf)
 				if err2 != nil {
-					t.Logf("client: Read returned %v", err2)
+					log.Infof("client: Read returned %v", err2)
+					assert.Equal(t, StreamStateClosed, stream.State())
 					break
 				}
+
+				log.Infof("client: received %d bytes (%d)", n, numClientReceived)
+				assert.Equal(t, 0, bytes.Compare(buf[:n], messages[numClientReceived]), "should receive HELLO")
+				numClientReceived++
 			}
-			close(done)
 		}()
 
-		log.Info("client stream ready")
-		close(clientStreamReady)
+		// Send messages to the server
+		for i := 0; i < numMessages; i++ {
+			_, err = stream.Write(messages[i])
+			assert.NoError(t, err, "should succeed")
+		}
 
-		<-clientStartClose
+		if dropReconfigChunk {
+			venv.dropNextReconfigChunk(1)
+		}
 
-		// drop next 1 RECONFIG chunk
-		venv.dropNextReconfigChunk(1)
-
+		// Immediately close the stream
 		err = stream.Close()
 		assert.NoError(t, err, "should succeed")
+		assert.Equal(t, StreamStateClosing, stream.State())
 
 		log.Info("client wait for exit reading..")
-		<-done
+		<-clientShutDown
 
-		<-shutDownClient
+		assert.Equal(t, numMessages, numServerReceived, "all messages should be received")
+		assert.Equal(t, numMessages, numClientReceived, "all messages should be received")
 
+		_, err = stream.Write([]byte{1})
+
+		assert.Equal(t, err, errStreamClosed, "after closed should not allow write")
 		// Check if RECONFIG was actually dropped
 		assert.Equal(t, 0, venv.numToDropReconfig, "should be zero")
 
@@ -539,26 +554,15 @@ func TestStreamClose(t *testing.T) {
 		pendingReconfigs := len(assoc.reconfigs)
 		assoc.lock.RUnlock()
 		assert.Equal(t, 0, pendingReconfigs, "should be zero")
+	}
 
-		log.Info("client closing")
-	}()
+	t.Run("without dropping Reconfig", func(t *testing.T) {
+		loopBackTest(t, false)
+	})
 
-	// wait until both establish a stream
-	<-clientStreamReady
-	<-serverStreamReady
-
-	log.Info("stream ready")
-
-	// let client begin writing
-	log.Info("client start closing")
-	close(clientStartClose)
-
-	<-serverStreamClosed
-	close(shutDownClient)
-
-	<-clientShutDown
-	<-serverShutDown
-	log.Info("all done")
+	t.Run("with dropping Reconfig", func(t *testing.T) {
+		loopBackTest(t, true)
+	})
 }
 
 // this test case reproduces the issue mentioned in


### PR DESCRIPTION
This reverts commit c0159aa2d49c240362038edf88baa8a9e6cfcede.

@jerry-tao @enobufs, the reverted commit made sense in theory but it's causing a regression in what https://github.com/pion/webrtc appears to expect in terms of data channel closing behavior with respect to pending writes on the sender side. More specifically, `TestEOF/Detach` started to fail where we expected that when the sender did a write followed by close, that the reader would see those writes and then see an EOF. That is to say, the enqueued writes are lost due to these changes. It doesn't seem like this change fixed any correctness issues with regards to the spec so it seems like we should revert it so as to unblock other changes in this v1.8.x. v1.8.4 is currently published but is now broken/flaky. https://github.com/pion/sctp/pull/254 attempted to fix this but it introduced more issues due to how we lose a lot of context when we `Close` in that we don't know why we are closing (inbound reset or user requested).