### PR TITLE
Don't call String in call to Debugf

### DIFF
--- a/association.go
+++ b/association.go
@@ -775,7 +775,7 @@ func (a *Association) gatherOutboundSackPackets(rawPackets [][]byte) [][]byte {
 	if a.ackState == ackStateImmediate {
 		a.ackState = ackStateIdle
 		sack := a.createSelectiveAckChunk()
-		a.log.Debugf("[%s] sending SACK: %s", a.name, sack.String())
+		a.log.Debugf("[%s] sending SACK: %s", a.name, sack)
 		raw, err := a.createPacket([]chunk{sack}).marshal()
 		if err != nil {
 			a.log.Warnf("[%s] failed to serialize a SACK packet", a.name)


### PR DESCRIPTION
The call to String was being executed unconditionally, even when
logging was disabled.  Fortunately, it's not needed.

This shaves some 10-15% off the time needed to do bulk receives.
