### PR TITLE
check if deadline timer has been cancelled before signaling

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -175,6 +175,11 @@ func (s *Stream) SetReadDeadline(deadline time.Time) error {
 				t.Stop()
 				return
 			case <-t.C:
+				select {
+				case <-readTimeoutCancel:
+					return
+				default:
+				}
 				s.lock.Lock()
 				if s.readErr == nil {
 					s.readErr = ErrReadDeadlineExceeded


### PR DESCRIPTION
When a timer expires we should check if the timer has been cancelled. In busy systems, an old timer can trigger DeadlineExceeded error even when the caller had correctly updated the deadline. 

I'm observing this here, in my admittedly complicated use case.
https://github.com/libp2p/go-libp2p/actions/runs/7070633636/job/19247525950?pr=2615

I was observing this in my code and have since rewritten to ignore deadline exceeded errors from the library and do something adhoc in my code. Because some times a previously set deadline update could trigger a Deadline exceeded error. 
https://github.com/libp2p/go-libp2p/blob/sukun/webrtc-fin-ack/p2p/transport/webrtc/stream.go#L285-L290