### PR TITLE
[WIP] Fix goroutine leakage

### DIFF
--- a/association.go
+++ b/association.go
@@ -264,6 +264,7 @@ func createClientWithContext(ctx context.Context, config Config) (*Association, 
 	select {
 	case <-ctx.Done():
 		a.log.Errorf("[%s] client handshake canceled: state=%s", a.name, getAssociationStateString(a.getState()))
+		a.Close() // nolint:errcheck,gosec
 		return nil, ctx.Err()
 	case err := <-a.handshakeCompletedCh:
 		if err != nil {

--- a/association_test.go
+++ b/association_test.go
@@ -2382,8 +2382,7 @@ func (c *fakeEchoConn) SetWriteDeadline(time.Time) error { return nil }
 func TestRoutineLeak(t *testing.T) {
 	loggerFactory := logging.NewDefaultLoggerFactory()
 	t.Run("Close failed", func(t *testing.T) {
-		runtime.GC()
-		n0 := runtime.NumGoroutine()
+		checkGoroutineLeaks(t)
 
 		conn := newFakeEchoConn(io.EOF)
 		a, err := Client(Config{NetConn: conn, LoggerFactory: loggerFactory})
@@ -2403,12 +2402,9 @@ func TestRoutineLeak(t *testing.T) {
 			t.Errorf("closeWriteLoopCh is expected to be closed, but not")
 		}
 		_ = a
-		runtime.GC()
-		assert.Equal(t, n0, runtime.NumGoroutine(), "goroutine is leaked")
 	})
 	t.Run("Connection closed by remote host", func(t *testing.T) {
-		runtime.GC()
-		n0 := runtime.NumGoroutine()
+		checkGoroutineLeaks(t)
 
 		conn := newFakeEchoConn(nil)
 		a, err := Client(Config{NetConn: conn, LoggerFactory: loggerFactory})
@@ -2429,8 +2425,6 @@ func TestRoutineLeak(t *testing.T) {
 		default:
 			t.Errorf("closeWriteLoopCh is expected to be closed, but not")
 		}
-		runtime.GC()
-		assert.Equal(t, n0, runtime.NumGoroutine(), "goroutine is leaked")
 	})
 }
 
@@ -2673,13 +2667,7 @@ loop:
 }
 
 func TestAssociation_Shutdown(t *testing.T) {
-	runtime.GC()
-	n0 := runtime.NumGoroutine()
-
-	defer func() {
-		runtime.GC()
-		assert.Equal(t, n0, runtime.NumGoroutine(), "goroutine is leaked")
-	}()
+	checkGoroutineLeaks(t)
 
 	a1, a2, err := createAssocs(t)
 	require.NoError(t, err)
@@ -2717,13 +2705,7 @@ func TestAssociation_Shutdown(t *testing.T) {
 }
 
 func TestAssociation_ShutdownDuringWrite(t *testing.T) {
-	runtime.GC()
-	n0 := runtime.NumGoroutine()
-
-	defer func() {
-		runtime.GC()
-		assert.Equal(t, n0, runtime.NumGoroutine(), "goroutine is leaked")
-	}()
+	checkGoroutineLeaks(t)
 
 	a1, a2, err := createAssocs(t)
 	require.NoError(t, err)
@@ -2934,13 +2916,7 @@ func TestAssociation_HandlePacketInCookieWaitState(t *testing.T) {
 }
 
 func TestAssociation_Abort(t *testing.T) {
-	runtime.GC()
-	n0 := runtime.NumGoroutine()
-
-	defer func() {
-		runtime.GC()
-		assert.Equal(t, n0, runtime.NumGoroutine(), "goroutine is leaked")
-	}()
+	checkGoroutineLeaks(t)
 
 	a1, a2, err := createAssocs(t)
 	require.NoError(t, err)


### PR DESCRIPTION
#### Description
* Added reproducible leakage check along with a fix.
* Fixed a test case that had a goroutine that did not exit.
* Ubuntu linux appears to have a bug causing initial packet exchange to fail (see issue #270 for details). To workaround it, the test tool `createAssocs()` has been updated to use "dumbConn2" (similar to the existing "dumbConn" which uses test.Bridge.) instead of using kernel routing between the two net.Conn endpoints.

#### Reference issue
Fixes #270
