### PR TITLE
Reduce RTO.Initial to 1 second

### DIFF
--- a/rtx_timer.go
+++ b/rtx_timer.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	rtoInitial     float64 = 3.0 * 1000  // msec
+	rtoInitial     float64 = 1.0 * 1000  // msec
 	rtoMin         float64 = 1.0 * 1000  // msec
 	rtoMax         float64 = 60.0 * 1000 // msec
 	rtoAlpha       float64 = 0.125


### PR DESCRIPTION
This is the default in [RFC 9260](https://www.rfc-editor.org/rfc/rfc9260.html#section-16).