### PR TITLE
Fix checksum check for received packets

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -126,8 +126,8 @@ func (p *packet) unmarshal(doChecksum bool, raw []byte) error {
 		offset += chunkHeaderSize + c.valueLength() + chunkValuePadding
 	}
 
-	if doChecksum {
-		theirChecksum := binary.LittleEndian.Uint32(raw[8:])
+	theirChecksum := binary.LittleEndian.Uint32(raw[8:])
+	if theirChecksum != 0 || doChecksum {
 		ourChecksum := generatePacketChecksum(raw)
 		if theirChecksum != ourChecksum {
 			return fmt.Errorf("%w: %d ours: %d", ErrChecksumMismatch, theirChecksum, ourChecksum)


### PR DESCRIPTION
Only the following packets should be accepted:
* Packets with a correct CRC32c checksum.
* Packets with an incorrect zero checksum, if its acceptance is allowed.

In particular, packets with an incorrect non-zero CRC32c must be discarded.