### PR TITLE
Consider padding when bundling chunks in packets

### DIFF
--- a/association.go
+++ b/association.go
@@ -2238,14 +2238,15 @@ func (a *Association) bundleDataChunksIntoPackets(chunks []*chunkPayloadData) []
 		//   single packet.  Furthermore, DATA chunks being retransmitted MAY be
 		//   bundled with new DATA chunks, as long as the resulting packet size
 		//   does not exceed the path MTU.
-		if bytesInPacket+len(c.userData) > int(a.MTU()) {
+		chunkSizeInPacket := int(dataChunkHeaderSize) + len(c.userData)
+		chunkSizeInPacket += getPadding(chunkSizeInPacket)
+		if bytesInPacket+chunkSizeInPacket > int(a.MTU()) {
 			packets = append(packets, a.createPacket(chunksToSend))
 			chunksToSend = []chunk{}
 			bytesInPacket = int(commonHeaderSize)
 		}
-
 		chunksToSend = append(chunksToSend, c)
-		bytesInPacket += int(dataChunkHeaderSize) + len(c.userData)
+		bytesInPacket += chunkSizeInPacket
 	}
 
 	if len(chunksToSend) > 0 {

--- a/association_test.go
+++ b/association_test.go
@@ -3156,3 +3156,19 @@ func TestAssociation_ZeroChecksum(t *testing.T) {
 		require.NoError(t, a2.Close())
 	}
 }
+
+func TestDataChunkBundlingIntoPacket(t *testing.T) {
+	a := &Association{mtu: initialMTU}
+	chunks := make([]*chunkPayloadData, 300)
+	for i := 0; i < 300; i++ {
+		chunks[i] = &chunkPayloadData{userData: []byte{1}}
+	}
+	packets := a.bundleDataChunksIntoPackets(chunks)
+	for _, p := range packets {
+		raw, err := p.marshal(false)
+		require.NoError(t, err)
+		if len(raw) > int(initialMTU) {
+			t.Error("packet too long: ", len(raw))
+		}
+	}
+}


### PR DESCRIPTION
Currently padding is not considered when decided how many chunks to bundle in to 1 packet. This causes some packets to exceed the MTU size. See the added test for a repro. 