### PR TITLE
Various cleanup and fixes

### DIFF
--- a/association_stats.go
+++ b/association_stats.go
@@ -8,11 +8,30 @@ import (
 )
 
 type associationStats struct {
+	nPackets     uint64
+	nPacketsSent uint64
 	nDATAs       uint64
 	nSACKs       uint64
+	nSACKsSent   uint64
 	nT3Timeouts  uint64
 	nAckTimeouts uint64
 	nFastRetrans uint64
+}
+
+func (s *associationStats) incPackets() {
+	atomic.AddUint64(&s.nPackets, 1)
+}
+
+func (s *associationStats) getNumPackets() uint64 {
+	return atomic.LoadUint64(&s.nPackets)
+}
+
+func (s *associationStats) incPacketsSent() {
+	atomic.AddUint64(&s.nPacketsSent, 1)
+}
+
+func (s *associationStats) getNumPacketsSent() uint64 {
+	return atomic.LoadUint64(&s.nPacketsSent)
 }
 
 func (s *associationStats) incDATAs() {
@@ -29,6 +48,14 @@ func (s *associationStats) incSACKs() {
 
 func (s *associationStats) getNumSACKs() uint64 {
 	return atomic.LoadUint64(&s.nSACKs)
+}
+
+func (s *associationStats) incSACKsSent() {
+	atomic.AddUint64(&s.nSACKsSent, 1)
+}
+
+func (s *associationStats) getNumSACKsSent() uint64 {
+	return atomic.LoadUint64(&s.nSACKsSent)
 }
 
 func (s *associationStats) incT3Timeouts() {
@@ -56,8 +83,11 @@ func (s *associationStats) getNumFastRetrans() uint64 {
 }
 
 func (s *associationStats) reset() {
+	atomic.StoreUint64(&s.nPackets, 0)
+	atomic.StoreUint64(&s.nPacketsSent, 0)
 	atomic.StoreUint64(&s.nDATAs, 0)
 	atomic.StoreUint64(&s.nSACKs, 0)
+	atomic.StoreUint64(&s.nSACKsSent, 0)
 	atomic.StoreUint64(&s.nT3Timeouts, 0)
 	atomic.StoreUint64(&s.nAckTimeouts, 0)
 	atomic.StoreUint64(&s.nFastRetrans, 0)

--- a/association_test.go
+++ b/association_test.go
@@ -257,6 +257,7 @@ func createNewAssociationPair(br *test.Bridge, ackMode int, recvBufSize uint32) 
 
 	go func() {
 		a0, err0 = Client(Config{
+			Name:                 "a0",
 			NetConn:              br.GetConn0(),
 			MaxReceiveBufferSize: recvBufSize,
 			LoggerFactory:        loggerFactory,
@@ -264,7 +265,11 @@ func createNewAssociationPair(br *test.Bridge, ackMode int, recvBufSize uint32) 
 		handshake0Ch <- true
 	}()
 	go func() {
-		a1, err1 = Client(Config{
+		// we could have two "client"s here but it's more
+		// standard to have one peer starting initialization and
+		// another waiting for the initialization to be requested (INIT).
+		a1, err1 = Server(Config{
+			Name:                 "a1",
 			NetConn:              br.GetConn1(),
 			MaxReceiveBufferSize: recvBufSize,
 			LoggerFactory:        loggerFactory,
@@ -1752,7 +1757,7 @@ func TestAssocT3RtxTimer(t *testing.T) {
 }
 
 func TestAssocCongestionControl(t *testing.T) {
-	// sbuf - large enobh not to be bundled
+	// sbuf - large enough not to be bundled
 	sbuf := make([]byte, 1000)
 	for i := 0; i < len(sbuf); i++ {
 		sbuf[i] = byte(i & 0xcc)

--- a/chunk_payload_data.go
+++ b/chunk_payload_data.go
@@ -206,3 +206,7 @@ func (p *chunkPayloadData) setAllInflight() {
 		}
 	}
 }
+
+func (p *chunkPayloadData) isFragmented() bool {
+	return !(p.head == nil && p.beginningFragment && p.endingFragment)
+}

--- a/control_queue.go
+++ b/control_queue.go
@@ -3,9 +3,14 @@
 
 package sctp
 
+import (
+	"sync"
+)
+
 // control queue
 
 type controlQueue struct {
+	mu    sync.RWMutex
 	queue []*packet
 }
 
@@ -14,19 +19,28 @@ func newControlQueue() *controlQueue {
 }
 
 func (q *controlQueue) push(c *packet) {
+	q.mu.Lock()
 	q.queue = append(q.queue, c)
+	q.mu.Unlock()
 }
 
 func (q *controlQueue) pushAll(packets []*packet) {
+	q.mu.Lock()
 	q.queue = append(q.queue, packets...)
+	q.mu.Unlock()
 }
 
 func (q *controlQueue) popAll() []*packet {
+	q.mu.Lock()
 	packets := q.queue
 	q.queue = []*packet{}
+	q.mu.Unlock()
 	return packets
 }
 
 func (q *controlQueue) size() int {
-	return len(q.queue)
+	q.mu.RLock()
+	size := len(q.queue)
+	q.mu.RUnlock()
+	return size
 }

--- a/packet_test.go
+++ b/packet_test.go
@@ -20,10 +20,10 @@ func TestPacketUnmarshal(t *testing.T) {
 	switch {
 	case err != nil:
 		t.Errorf("Unmarshal failed for SCTP packet with no chunks: %v", err)
-	case pkt.sourcePort != 5000:
-		t.Errorf("Unmarshal passed for SCTP packet, but got incorrect source port exp: %d act: %d", 5000, pkt.sourcePort)
-	case pkt.destinationPort != 5000:
-		t.Errorf("Unmarshal passed for SCTP packet, but got incorrect destination port exp: %d act: %d", 5000, pkt.destinationPort)
+	case pkt.sourcePort != defaultSCTPSrcDstPort:
+		t.Errorf("Unmarshal passed for SCTP packet, but got incorrect source port exp: %d act: %d", defaultSCTPSrcDstPort, pkt.sourcePort)
+	case pkt.destinationPort != defaultSCTPSrcDstPort:
+		t.Errorf("Unmarshal passed for SCTP packet, but got incorrect destination port exp: %d act: %d", defaultSCTPSrcDstPort, pkt.destinationPort)
 	case pkt.verificationTag != 0:
 		t.Errorf("Unmarshal passed for SCTP packet, but got incorrect verification tag exp: %d act: %d", 0, pkt.verificationTag)
 	}

--- a/rtx_timer.go
+++ b/rtx_timer.go
@@ -10,14 +10,28 @@ import (
 )
 
 const (
-	rtoInitial     float64 = 1.0 * 1000  // msec
-	rtoMin         float64 = 1.0 * 1000  // msec
-	rtoMax         float64 = 60.0 * 1000 // msec
-	rtoAlpha       float64 = 0.125
-	rtoBeta        float64 = 0.25
-	maxInitRetrans uint    = 8
-	pathMaxRetrans uint    = 5
-	noMaxRetrans   uint    = 0
+	// RTO.Initial
+	rtoInitial float64 = 1.0 * 1000 // msec
+
+	// RTO.Min
+	rtoMin float64 = 1.0 * 1000 // msec
+
+	// RTO.Max
+	rtoMax float64 = 60.0 * 1000 // msec
+
+	// RTO.Alpha
+	rtoAlpha float64 = 0.125
+
+	// RTO.Beta
+	rtoBeta float64 = 0.25
+
+	// Max.Init.Retransmits:
+	maxInitRetrans uint = 8
+
+	// Path.Max.Retrans
+	pathMaxRetrans uint = 5
+
+	noMaxRetrans uint = 0
 )
 
 // rtoManager manages Rtx timeout values.

--- a/vnet_test.go
+++ b/vnet_test.go
@@ -202,8 +202,8 @@ func testRwndFull(t *testing.T, unordered bool) {
 		defer close(serverShutDown)
 		// connected UDP conn for server
 		conn, err := venv.net0.DialUDP("udp4",
-			&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5000},
-			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5000},
+			&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: defaultSCTPSrcDstPort},
+			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: defaultSCTPSrcDstPort},
 		)
 		if !assert.NoError(t, err, "should succeed") {
 			return
@@ -277,8 +277,8 @@ func testRwndFull(t *testing.T, unordered bool) {
 		defer close(clientShutDown)
 		// connected UDP conn for client
 		conn, err := venv.net1.DialUDP("udp4",
-			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5000},
-			&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5000},
+			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: defaultSCTPSrcDstPort},
+			&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: defaultSCTPSrcDstPort},
 		)
 		if !assert.NoError(t, err, "should succeed") {
 			return
@@ -435,8 +435,8 @@ func TestStreamClose(t *testing.T) {
 			defer close(serverShutDown)
 			// connected UDP conn for server
 			conn, innerErr := venv.net0.DialUDP("udp4",
-				&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5000},
-				&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5000},
+				&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: defaultSCTPSrcDstPort},
+				&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: defaultSCTPSrcDstPort},
 			)
 			if !assert.NoError(t, innerErr, "should succeed") {
 				return
@@ -485,8 +485,8 @@ func TestStreamClose(t *testing.T) {
 
 		// connected UDP conn for client
 		conn, err := venv.net1.DialUDP("udp4",
-			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5000},
-			&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5000},
+			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: defaultSCTPSrcDstPort},
+			&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: defaultSCTPSrcDstPort},
 		)
 		if !assert.NoError(t, err, "should succeed") {
 			return
@@ -620,8 +620,8 @@ func TestCookieEchoRetransmission(t *testing.T) {
 		defer close(serverShutDown)
 		// connected UDP conn for server
 		conn, err := venv.net0.DialUDP("udp4",
-			&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5000},
-			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5000},
+			&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: defaultSCTPSrcDstPort},
+			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: defaultSCTPSrcDstPort},
 		)
 		if !assert.NoError(t, err, "should succeed") {
 			return
@@ -650,8 +650,8 @@ func TestCookieEchoRetransmission(t *testing.T) {
 		defer close(clientShutDown)
 		// connected UDP conn for client
 		conn, err := venv.net1.DialUDP("udp4",
-			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5000},
-			&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5000},
+			&net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: defaultSCTPSrcDstPort},
+			&net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: defaultSCTPSrcDstPort},
 		)
 		if !assert.NoError(t, err, "should succeed") {
 			return


### PR DESCRIPTION
#### Description
I've spent the past week debugging what's going on with throughput and stalling when sending a lot of small and large data through SCTP. I have draft work in my fork that adds the modified Nagle's algorithm as well as a missing sender side implementation of addressing Silly Window Syndrome (this is a MUST in the RFC). Both of these help considerably on increasing throughput and stability but I need to verify it doesn't cause any unexpected regressions on throughput before moving forward. They also are hiding what I think may be some bug in this library that causes no progress to be made, even when RTXs are happening, so I want to solve that first.

#### Changes
- Add comments referring back to RFCs
- Allow associations to be named
- Fix some typos
- Fix a bug where we unmarshal a packet twice, doubling it's size when we are doing mandatory checksumming
- Add some more stats for debugging
- Make useZeroChecksum atomic
- Add locks to queues to avoid caught races
