### PR TITLE
Configurable RTOMax - fix #181

### DIFF
--- a/rtx_timer.go
+++ b/rtx_timer.go
@@ -12,7 +12,7 @@ import (
 const (
 	rtoInitial     float64 = 1.0 * 1000  // msec
 	rtoMin         float64 = 1.0 * 1000  // msec
-	rtoMax         float64 = 60.0 * 1000 // msec
+	defaultRTOMax  float64 = 60.0 * 1000 // msec
 	rtoAlpha       float64 = 0.125
 	rtoBeta        float64 = 0.25
 	maxInitRetrans uint    = 8
@@ -28,13 +28,20 @@ type rtoManager struct {
 	rto      float64
 	noUpdate bool
 	mutex    sync.RWMutex
+	rtoMax   float64
 }
 
 // newRTOManager creates a new rtoManager.
-func newRTOManager() *rtoManager {
-	return &rtoManager{
-		rto: rtoInitial,
+func newRTOManager(rtoMax float64) *rtoManager {
+	mgr := rtoManager{
+		rto:    rtoInitial,
+		rtoMax: rtoMax,
 	}
+	if mgr.rtoMax == 0 {
+		mgr.rtoMax = defaultRTOMax
+	}
+	return &mgr
+
 }
 
 // setNewRTT takes a newly measured RTT then adjust the RTO in msec.
@@ -55,7 +62,7 @@ func (m *rtoManager) setNewRTT(rtt float64) float64 {
 		m.rttvar = (1-rtoBeta)*m.rttvar + rtoBeta*(math.Abs(m.srtt-rtt))
 		m.srtt = (1-rtoAlpha)*m.srtt + rtoAlpha*rtt
 	}
-	m.rto = math.Min(math.Max(m.srtt+4*m.rttvar, rtoMin), rtoMax)
+	m.rto = math.Min(math.Max(m.srtt+4*m.rttvar, rtoMin), m.rtoMax)
 	return m.srtt
 }
 
@@ -106,6 +113,7 @@ type rtxTimer struct {
 	stopFunc   stopTimerLoop
 	closed     bool
 	mutex      sync.RWMutex
+	rtoMax     float64
 }
 
 type stopTimerLoop func()
@@ -113,12 +121,19 @@ type stopTimerLoop func()
 // newRTXTimer creates a new retransmission timer.
 // if maxRetrans is set to 0, it will keep retransmitting until stop() is called.
 // (it will never make onRetransmissionFailure() callback.
-func newRTXTimer(id int, observer rtxTimerObserver, maxRetrans uint) *rtxTimer {
-	return &rtxTimer{
+func newRTXTimer(id int, observer rtxTimerObserver, maxRetrans uint,
+	rtoMax float64) *rtxTimer {
+
+	timer := rtxTimer{
 		id:         id,
 		observer:   observer,
 		maxRetrans: maxRetrans,
+		rtoMax:     rtoMax,
 	}
+	if timer.rtoMax == 0 {
+		timer.rtoMax = defaultRTOMax
+	}
+	return &timer
 }
 
 // start starts the timer.
@@ -148,7 +163,7 @@ func (t *rtxTimer) start(rto float64) bool {
 		canceling := false
 
 		for !canceling {
-			timeout := calculateNextTimeout(rto, nRtos)
+			timeout := calculateNextTimeout(rto, nRtos, t.rtoMax)
 			timer := time.NewTimer(time.Duration(timeout) * time.Millisecond)
 
 			select {
@@ -208,7 +223,7 @@ func (t *rtxTimer) isRunning() bool {
 	return (t.stopFunc != nil)
 }
 
-func calculateNextTimeout(rto float64, nRtos uint) float64 {
+func calculateNextTimeout(rto float64, nRtos uint, rtoMax float64) float64 {
 	// RFC 4096 sec 6.3.3.  Handle T3-rtx Expiration
 	//   E2)  For the destination address for which the timer expires, set RTO
 	//        <- RTO * 2 ("back off the timer").  The maximum value discussed

--- a/rtx_timer.go
+++ b/rtx_timer.go
@@ -41,7 +41,6 @@ func newRTOManager(rtoMax float64) *rtoManager {
 		mgr.rtoMax = defaultRTOMax
 	}
 	return &mgr
-
 }
 
 // setNewRTT takes a newly measured RTT then adjust the RTO in msec.
@@ -122,8 +121,8 @@ type stopTimerLoop func()
 // if maxRetrans is set to 0, it will keep retransmitting until stop() is called.
 // (it will never make onRetransmissionFailure() callback.
 func newRTXTimer(id int, observer rtxTimerObserver, maxRetrans uint,
-	rtoMax float64) *rtxTimer {
-
+	rtoMax float64,
+) *rtxTimer {
 	timer := rtxTimer{
 		id:         id,
 		observer:   observer,


### PR DESCRIPTION
#### Description

This change adds RTOMax to Config letting the user cap the retransmission timer without breaking compatibility. If RTOMax is 0 the current value of 60 seconds is used.

#### Reference issue
Start fixing #181, needs another PR in webrtc to support this feature
