### PR TITLE
Allow Associations to be named

### DIFF
--- a/association.go
+++ b/association.go
@@ -232,6 +232,7 @@ type Association struct {
 // Config collects the arguments to createAssociation construction into
 // a single structure
 type Config struct {
+	Name                 string
 	NetConn              net.Conn
 	MaxReceiveBufferSize uint32
 	MaxMessageSize       uint32
@@ -329,9 +330,12 @@ func createAssociation(config Config) *Association {
 		silentError:             ErrSilentlyDiscard,
 		stats:                   &associationStats{},
 		log:                     config.LoggerFactory.NewLogger("sctp"),
+		name:                    config.Name,
 	}
 
-	a.name = fmt.Sprintf("%p", a)
+	if a.name == "" {
+		a.name = fmt.Sprintf("%p", a)
+	}
 
 	// RFC 4690 Sec 7.2.1
 	//  o  The initial cwnd before DATA transmission or after a sufficiently

--- a/association_test.go
+++ b/association_test.go
@@ -257,6 +257,7 @@ func createNewAssociationPair(br *test.Bridge, ackMode int, recvBufSize uint32) 
 
 	go func() {
 		a0, err0 = Client(Config{
+			Name:                 "a0",
 			NetConn:              br.GetConn0(),
 			MaxReceiveBufferSize: recvBufSize,
 			LoggerFactory:        loggerFactory,
@@ -265,6 +266,7 @@ func createNewAssociationPair(br *test.Bridge, ackMode int, recvBufSize uint32) 
 	}()
 	go func() {
 		a1, err1 = Client(Config{
+			Name:                 "a1",
 			NetConn:              br.GetConn1(),
 			MaxReceiveBufferSize: recvBufSize,
 			LoggerFactory:        loggerFactory,


### PR DESCRIPTION
#### Description
This nice when logs get verbose and you don't want to remember pointer values in your head :)
