### PR TITLE
Fix zero checksum usage

### DIFF
--- a/association.go
+++ b/association.go
@@ -177,8 +177,8 @@ type Association struct {
 	cumulativeTSNAckPoint   uint32
 	advancedPeerTSNAckPoint uint32
 	useForwardTSN           bool
-	useZeroChecksum         bool
-	requestZeroChecksum     bool
+	sendZeroChecksum        bool
+	recvZeroChecksum        bool
 
 	// Congestion control parameters
 	maxReceiveBufferSize uint32
@@ -325,7 +325,7 @@ func createAssociation(config Config) *Association {
 		handshakeCompletedCh:    make(chan error),
 		cumulativeTSNAckPoint:   tsn - 1,
 		advancedPeerTSNAckPoint: tsn - 1,
-		requestZeroChecksum:     config.EnableZeroChecksum,
+		recvZeroChecksum:        config.EnableZeroChecksum,
 		silentError:             ErrSilentlyDiscard,
 		stats:                   &associationStats{},
 		log:                     config.LoggerFactory.NewLogger("sctp"),
@@ -369,7 +369,7 @@ func (a *Association) init(isClient bool) {
 		init.advertisedReceiverWindowCredit = a.maxReceiveBufferSize
 		setSupportedExtensions(&init.chunkInitCommon)
 
-		if a.requestZeroChecksum {
+		if a.recvZeroChecksum {
 			init.params = append(init.params, &paramZeroChecksumAcceptable{edmid: dtlsErrorDetectionMethod})
 		}
 
@@ -632,7 +632,7 @@ func (a *Association) unregisterStream(s *Stream, err error) {
 func chunkMandatoryChecksum(cc []chunk) bool {
 	for _, c := range cc {
 		switch c.(type) {
-		case *chunkInit, *chunkInitAck, *chunkCookieEcho:
+		case *chunkInit, *chunkCookieEcho:
 			return true
 		}
 	}
@@ -640,12 +640,12 @@ func chunkMandatoryChecksum(cc []chunk) bool {
 }
 
 func (a *Association) marshalPacket(p *packet) ([]byte, error) {
-	return p.marshal(!a.useZeroChecksum || chunkMandatoryChecksum(p.chunks))
+	return p.marshal(!a.sendZeroChecksum || chunkMandatoryChecksum(p.chunks))
 }
 
 func (a *Association) unmarshalPacket(raw []byte) (*packet, error) {
 	p := &packet{}
-	if err := p.unmarshal(!a.useZeroChecksum, raw); err != nil {
+	if err := p.unmarshal(!a.recvZeroChecksum, raw); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -1125,7 +1125,6 @@ func (a *Association) handleInit(p *packet, i *chunkInit) ([]*packet, error) {
 	// subtracting one from it.
 	a.peerLastTSN = i.initialTSN - 1
 
-	peerHasZeroChecksum := false
 	for _, param := range i.params {
 		switch v := param.(type) { // nolint:gocritic
 		case *paramSupportedExtensions:
@@ -1136,7 +1135,7 @@ func (a *Association) handleInit(p *packet, i *chunkInit) ([]*packet, error) {
 				}
 			}
 		case *paramZeroChecksumAcceptable:
-			peerHasZeroChecksum = v.edmid == dtlsErrorDetectionMethod
+			a.sendZeroChecksum = v.edmid == dtlsErrorDetectionMethod
 		}
 	}
 
@@ -1166,11 +1165,10 @@ func (a *Association) handleInit(p *packet, i *chunkInit) ([]*packet, error) {
 
 	initAck.params = []param{a.myCookie}
 
-	if peerHasZeroChecksum {
+	if a.recvZeroChecksum {
 		initAck.params = append(initAck.params, &paramZeroChecksumAcceptable{edmid: dtlsErrorDetectionMethod})
-		a.useZeroChecksum = true
 	}
-	a.log.Debugf("[%s] useZeroChecksum=%t (on init)", a.name, a.useZeroChecksum)
+	a.log.Debugf("[%s] sendZeroChecksum=%t (on init)", a.name, a.sendZeroChecksum)
 
 	setSupportedExtensions(&initAck.chunkInitCommon)
 
@@ -1230,11 +1228,11 @@ func (a *Association) handleInitAck(p *packet, i *chunkInitAck) error {
 				}
 			}
 		case *paramZeroChecksumAcceptable:
-			a.useZeroChecksum = v.edmid == dtlsErrorDetectionMethod
+			a.sendZeroChecksum = v.edmid == dtlsErrorDetectionMethod
 		}
 	}
 
-	a.log.Debugf("[%s] useZeroChecksum=%t (on initAck)", a.name, a.useZeroChecksum)
+	a.log.Debugf("[%s] sendZeroChecksum=%t (on initAck)", a.name, a.sendZeroChecksum)
 
 	if !a.useForwardTSN {
 		a.log.Warnf("[%s] not using ForwardTSN (on initAck)", a.name)

--- a/association_test.go
+++ b/association_test.go
@@ -3082,7 +3082,7 @@ func (c customLogger) Trace(string)                  {}
 func (c customLogger) Tracef(string, ...interface{}) {}
 func (c customLogger) Debug(string)                  {}
 func (c customLogger) Debugf(format string, args ...interface{}) {
-	if format == "[%s] useZeroChecksum=%t (on initAck)" {
+	if format == "[%s] sendZeroChecksum=%t (on initAck)" {
 		assert.Equal(c.t, args[1], c.expectZeroChecksum)
 	}
 }
@@ -3108,8 +3108,8 @@ func TestAssociation_ZeroChecksum(t *testing.T) {
 	}{
 		{true, true, true},
 		{false, false, false},
-		{true, false, true},
-		{false, true, false},
+		{true, false, false},
+		{false, true, true},
 	} {
 		a1chan, a2chan := make(chan *Association), make(chan *Association)
 


### PR DESCRIPTION
zero checksum acceptance was implemented as a symmetrical feature, but this is not the way it is specified. Each side announces independently from the peer, that it can accept packets with an incorrect zero checksum. In particular, it is completely valid to send a packet containing an INIT ACK chunk with an incorrect zero checksum, as long as the peer announced the support in the INIT chunk.
