### PR TITLE
Fix incorrect fragmented chunk merge

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -265,7 +265,10 @@ func createNewAssociationPair(br *test.Bridge, ackMode int, recvBufSize uint32) 
 		handshake0Ch <- true
 	}()
 	go func() {
-		a1, err1 = Client(Config{
+		// we could have two "client"s here but it's more
+		// standard to have one peer starting initialization and
+		// another waiting for the initialization to be requested (INIT).
+		a1, err1 = Server(Config{
 			Name:                 "a1",
 			NetConn:              br.GetConn1(),
 			MaxReceiveBufferSize: recvBufSize,

--- a/chunk_payload_data.go
+++ b/chunk_payload_data.go
@@ -206,3 +206,7 @@ func (p *chunkPayloadData) setAllInflight() {
 		}
 	}
 }
+
+func (p *chunkPayloadData) isFragmented() bool {
+	return !(p.head == nil && p.beginningFragment && p.endingFragment)
+}


### PR DESCRIPTION
#### Description
This fixes a case where a chunk with the same SSN that is not fragmented is combined with a fragmented chunk. This can happen in a case where we send so many chunks that the SSN wraps.

