### PR TITLE
Update WriteSCTP outbound packet too large error

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -266,7 +265,7 @@ func (s *Stream) Write(p []byte) (n int, err error) {
 func (s *Stream) WriteSCTP(p []byte, ppi PayloadProtocolIdentifier) (int, error) {
 	maxMessageSize := s.association.MaxMessageSize()
 	if len(p) > int(maxMessageSize) {
-		return 0, fmt.Errorf("%w: %v", ErrOutboundPacketTooLarge, math.MaxUint16)
+		return 0, fmt.Errorf("%w: %v", ErrOutboundPacketTooLarge, maxMessageSize)
 	}
 
 	if s.State() != StreamStateOpen {


### PR DESCRIPTION
At face value it looks like the error message from Stream.WriteSCTP() should report the exact maximum packet size it compared the actual packet size to.