### PR TITLE
Limit maximum tsn queued by the association

### DIFF
--- a/association.go
+++ b/association.go
@@ -1124,7 +1124,7 @@ func (a *Association) SRTT() float64 {
 // getMaxTSNOffset returns the maximum offset over the current cummulative TSN that
 // we are willing to enqueue. Limiting the maximum offset limits the number of
 // tsns we have in the payloadQueue map. This ensures that we don't use too much space in
-// the map itself. This also ensures that we keep the bytes utilised in the receive
+// the map itself. This also ensures that we keep the bytes utilized in the receive
 // buffer within a small multiple of the user provided max receive buffer size.
 func (a *Association) getMaxTSNOffset() uint32 {
 	// 4 is a magic number here. There is no theory behind this.

--- a/association.go
+++ b/association.go
@@ -99,6 +99,12 @@ const (
 // other constants
 const (
 	acceptChSize = 16
+	// maxTSNOffset is the maximum offset of a received chunk TSN from the cummulative TSN
+	// we have seen so far that we will enqueue.
+	// For a chunk to be enqueued chunk.tsn < cummulativeTSN + maxTSNOffset
+	// This allows us to not enqueue too many bytes over the receive window in case of out
+	// of order delivery. A buffer of 1000 TSNs implies an excess of roughly 2MB.
+	maxTSNOffset = 2000
 )
 
 func getAssociationStateString(a uint32) string {

--- a/payload_queue.go
+++ b/payload_queue.go
@@ -38,7 +38,7 @@ func (q *payloadQueue) updateSortedKeys() {
 
 func (q *payloadQueue) canPush(p *chunkPayloadData, cumulativeTSN uint32) bool {
 	_, ok := q.chunkMap[p.tsn]
-	if ok || sna32LTE(p.tsn, cumulativeTSN) {
+	if ok || sna32LTE(p.tsn, cumulativeTSN) || sna32GTE(p.tsn, cumulativeTSN+maxTSNOffset) {
 		return false
 	}
 	return true

--- a/payload_queue.go
+++ b/payload_queue.go
@@ -36,7 +36,7 @@ func (q *payloadQueue) updateSortedKeys() {
 	})
 }
 
-func (q *payloadQueue) canPush(p *chunkPayloadData, cumulativeTSN uint32) bool {
+func (q *payloadQueue) canPush(p *chunkPayloadData, cumulativeTSN uint32, maxTSNOffset uint32) bool {
 	_, ok := q.chunkMap[p.tsn]
 	if ok || sna32LTE(p.tsn, cumulativeTSN) || sna32GTE(p.tsn, cumulativeTSN+maxTSNOffset) {
 		return false


### PR DESCRIPTION
We can only ACK TSN offsets 64k from the cummulativeTSN so there's no point queuing higher TSNs