### PR TITLE
Update go.mod to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,18 @@
 module github.com/pion/sctp
 
 require (
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pion/logging v0.2.2
 	github.com/pion/randutil v0.1.0
 	github.com/pion/transport/v3 v3.0.2
 	github.com/stretchr/testify v1.9.0
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
 
-go 1.13
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+go 1.19


### PR DESCRIPTION
Part of changes required after https://github.com/pion/.goassets/pull/209. Related to https://github.com/pion/webrtc/issues/2292