### PR TITLE
Toggle the ZeroChecksum heuristics

### DIFF
--- a/association.go
+++ b/association.go
@@ -2556,9 +2556,9 @@ func (a *Association) onRetransmissionTimeout(id int, nRtos uint) {
 	defer a.lock.Unlock()
 
 	// TSN hasn't been incremented in 3 attempts. Speculatively
-	// disable ZeroChecksum because old Pion versions had a broken implementation
-	if a.cumulativeTSNAckPoint+1 == a.initialTSN && nRtos == 3 {
-		a.sendZeroChecksum = false
+	// toggle ZeroChecksum because old Pion versions had a broken implementation
+	if a.cumulativeTSNAckPoint+1 == a.initialTSN && nRtos%3 == 0 {
+		a.sendZeroChecksum = !a.sendZeroChecksum
 	}
 
 	if id == timerT1Init {


### PR DESCRIPTION
Toggle every 3 packets in cases of heavy packet loss to allow Association to recover

#### Description

#### Reference issue
Fixes #...
