### PR TITLE
Do not add streams after association is closed

### DIFF
--- a/association.go
+++ b/association.go
@@ -33,6 +33,7 @@ var (
 	ErrChunk                         = errors.New("abort chunk, with following errors")
 	ErrShutdownNonEstablished        = errors.New("shutdown called in non-established state")
 	ErrAssociationClosedBeforeConn   = errors.New("association closed before connecting")
+	ErrAssociationClosed             = errors.New("association closed")
 	ErrSilentlyDiscard               = errors.New("silently discard")
 	ErrInitNotStoredToSend           = errors.New("the init not stored to send")
 	ErrCookieEchoNotStoredToSend     = errors.New("cookieEcho not stored to send")
@@ -1504,6 +1505,11 @@ func (a *Association) getMyReceiverWindowCredit() uint32 {
 func (a *Association) OpenStream(streamIdentifier uint16, defaultPayloadType PayloadProtocolIdentifier) (*Stream, error) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
+
+	switch a.getState() {
+	case shutdownAckSent, shutdownPending, shutdownReceived, shutdownSent, closed:
+		return nil, ErrAssociationClosed
+	}
 
 	return a.getOrCreateStream(streamIdentifier, false, defaultPayloadType), nil
 }

--- a/association_test.go
+++ b/association_test.go
@@ -3455,3 +3455,19 @@ func TestAssociation_ReconfigRequestsLimited(t *testing.T) {
 	require.NoError(t, a1.Close())
 	require.NoError(t, a2.Close())
 }
+
+func TestAssociation_OpenStreamAfterClose(t *testing.T) {
+	checkGoroutineLeaks(t)
+
+	a1, a2, err := createAssocs()
+	require.NoError(t, err)
+
+	require.NoError(t, a1.Close())
+	require.NoError(t, a2.Close())
+
+	_, err = a1.OpenStream(1, PayloadTypeWebRTCString)
+	require.ErrorIs(t, err, ErrAssociationClosed)
+
+	_, err = a2.OpenStream(1, PayloadTypeWebRTCString)
+	require.ErrorIs(t, err, ErrAssociationClosed)
+}


### PR DESCRIPTION
Without this, there's a race between OpenStream and the readLoop unregistering streams. When the race happens, a stream is leaked and will get stuck in a read loop waiting forever.