### PR TITLE
Unblock handshake ch on close

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -3222,6 +3222,10 @@ func TestAssociation_Abort(t *testing.T) {
 
 // TestAssociation_createClientWithContext tests that the client is closed when the context is canceled.
 func TestAssociation_createClientWithContext(t *testing.T) {
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
 	checkGoroutineLeaks(t)
 
 	udp1, udp2 := createUDPConnPair()


### PR DESCRIPTION
Fixes:
```
panic: test timed out after 10m0s
running tests:
	TestAssociation_createClientWithContext (9m30s)

goroutine 381 [running]:
testing.(*M).startAlarm.func1()
	/usr/local/go/src/testing/testing.go:2366 +0x38c
created by time.goFunc
	/usr/local/go/src/time/sleep.go:177 +0x2f

goroutine 1 [chan receive, 9 minutes]:
testing.(*T).Run(0x8d42008, {0x82b13b0, 0x27}, 0x82bc794)
	/usr/local/go/src/testing/testing.go:1750 +0x3d8
testing.runTests.func1(0x8d42008)
	/usr/local/go/src/testing/testing.go:2161 +0x45
testing.tRunner(0x8d42008, 0x8d21dfc)
	/usr/local/go/src/testing/testing.go:1689 +0x125
testing.runTests(0x8c10220, {0x845e660, 0x56, 0x56}, {0xc1a6b70d06f1a027, 0x8bb2d357fb, 0x8460720})
	/usr/local/go/src/testing/testing.go:2159 +0x39d
testing.(*M).Run(0x8c16320)
	/usr/local/go/src/testing/testing.go:2027 +0x6d8
main.main()
	_testmain.go:219 +0x141

goroutine 434 [select, 9 minutes]:
github.com/pion/sctp.TestAssociation_createClientWithContext(0x8d42108)
	/go/src/github.com/pion/sctp/association_test.go:3267 +0x293
testing.tRunner(0x8d42108, 0x82bc794)
	/usr/local/go/src/testing/testing.go:1689 +0x125
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1742 +0x3b9

goroutine 435 [chan receive, 9 minutes]:
github.com/pion/sctp.(*Association).Close(0x9106008)
	/go/src/github.com/pion/sctp/association.go:508 +0xfc
github.com/pion/sctp.createClientWithContext({0x82fc480, 0x8c160f0}, {{0x0, 0x0}, {0x82fc8f4, 0x9030000}, 0x0, 0x0, 0x0, {0x82fb710, ...}, ...})
	/go/src/github.com/pion/sctp/association.go:296 +0x234
github.com/pion/sctp.TestAssociation_createClientWithContext.func1()
	/go/src/github.com/pion/sctp/association_test.go:3237 +0x89
created by github.com/pion/sctp.TestAssociation_createClientWithContext in goroutine 434
	/go/src/github.com/pion/sctp/association_test.go:3236 +0x153

goroutine 418 [chan send, 9 minutes]:
github.com/pion/sctp.(*Association).handleCookieEcho(0x9106008, 0x90962e0)
	/go/src/github.com/pion/sctp/association.go:1379 +0x229
github.com/pion/sctp.(*Association).handleChunk(0x9106008, 0x8fe4150, {0x82fc240, 0x90962e0})
	/go/src/github.com/pion/sctp/association.go:2542 +0x184
github.com/pion/sctp.(*Association).handleInbound(0x9106008, {0x8c72510, 0x30, 0x30})
	/go/src/github.com/pion/sctp/association.go:712 +0x2da
github.com/pion/sctp.(*Association).readLoop(0x9106008)
	/go/src/github.com/pion/sctp/association.go:607 +0x1f7
created by github.com/pion/sctp.(*Association).init in goroutine 435
	/go/src/github.com/pion/sctp/association.go:393 +0xab

goroutine 419 [sync.Mutex.Lock, 9 minutes]:
sync.runtime_SemacquireMutex(0x910601c, 0x0, 0x1)
	/usr/local/go/src/runtime/sema.go:77 +0x3f
sync.(*Mutex).lockSlow(0x9106018)
	/usr/local/go/src/sync/mutex.go:171 +0x247
sync.(*Mutex).Lock(0x9106018)
	/usr/local/go/src/sync/mutex.go:90 +0x4c
sync.(*RWMutex).Lock(0x9106018)
	/usr/local/go/src/sync/rwmutex.go:146 +0x23
github.com/pion/sctp.(*Association).gatherOutbound(0x9106008)
	/go/src/github.com/pion/sctp/association.go:962 +0x5c
github.com/pion/sctp.(*Association).writeLoop(0x9106008)
	/go/src/github.com/pion/sctp/association.go:622 +0x169
created by github.com/pion/sctp.(*Association).init in goroutine 435
```
