### PR TITLE
set close state before unregisterStream

### DIFF
--- a/association.go
+++ b/association.go
@@ -573,6 +573,7 @@ func (a *Association) readLoop() {
 		a.closeWriteLoopOnce.Do(func() { close(a.closeWriteLoopCh) })
 
 		a.lock.Lock()
+		a.setState(closed)
 		for _, s := range a.streams {
 			a.unregisterStream(s, closeErr)
 		}


### PR DESCRIPTION
Although `OpenStream` checks state before creating a stream, `readLoop`'s `unregisterStream` can be called outside of a direct `Close`. When this happens, `setState(closed)` happens **after** unregisterStream which is an incorrect ordering causing an `OpenStream` to proceed. readLoop should set the closed state prior to unregistering streams.

Repro with carefully placed sleeps to mimic an internal close of connections being closed:
```
diff --git a/association.go b/association.go
index 29e9978..2cf2539 100644
--- a/association.go
+++ b/association.go
@@ -578,6 +578,7 @@ func (a *Association) readLoop() {
 			a.unregisterStream(s, closeErr)
 		}
 		a.lock.Unlock()
+		println("unregged")
 		close(a.acceptCh)
 		close(a.readLoopCloseCh)
 
@@ -650,6 +651,8 @@ loop:
 		}
 	}
 
+	time.Sleep(3 * time.Second)
+	println("now closed")
 	a.setState(closed)
 	a.closeAllTimers()
 }
@@ -1504,13 +1507,18 @@ func (a *Association) getMyReceiverWindowCredit() uint32 {
 
 // OpenStream opens a stream
 func (a *Association) OpenStream(streamIdentifier uint16, defaultPayloadType PayloadProtocolIdentifier) (*Stream, error) {
+	time.Sleep(time.Second)
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
+	println("adding")
+
 	switch a.getState() {
 	case shutdownAckSent, shutdownPending, shutdownReceived, shutdownSent, closed:
+		println("no")
 		return nil, ErrAssociationClosed
 	}
+	println("yes")
 
 	return a.getOrCreateStream(streamIdentifier, false, defaultPayloadType), nil
 }
```