### PR TITLE
Set rwnd from InitChunk

### DIFF
--- a/association.go
+++ b/association.go
@@ -1264,6 +1264,9 @@ func (a *Association) handleInit(pkt *packet, initChunk *chunkInit) ([]*packet, 
 	// subtracting one from it.
 	a.payloadQueue.init(initChunk.initialTSN - 1)
 
+	a.setRWND(initChunk.advertisedReceiverWindowCredit)
+	a.log.Debugf("[%s] initial rwnd=%d", a.name, a.RWND())
+
 	for _, param := range initChunk.params {
 		switch v := param.(type) { // nolint:gocritic
 		case *paramSupportedExtensions:


### PR DESCRIPTION
The rwnd has not been initialized from InitChunk
then payload data will be hold in the pending
queue until first SACK is received.

