### PR TITLE
Don't discard data on io.ErrShortBuffer

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -165,7 +165,7 @@ func check(err error) {
 func pipeDump() (net.Conn, net.Conn) {
 	aConn := acceptDumbConn()
 
-	bConn, err := net.DialUDP("udp4", nil, aConn.LocalAddr().(*net.UDPAddr))
+	bConn, err := net.DialUDP("udp4", nil, aConn.LocalAddr().(*net.UDPAddr)) // nolint: forcetypeassert
 	check(err)
 
 	// Dumb handshake
@@ -827,7 +827,7 @@ func TestAssocReliable(t *testing.T) { //nolint:cyclop,maintidx
 		buf := make([]byte, 3)
 		n, ppi, err := s1.ReadSCTP(buf)
 		assert.Equal(t, err, io.ErrShortBuffer, "expected error to be io.ErrShortBuffer")
-		assert.Equal(t, n, 0, "unexpected length of received data")
+		assert.Equal(t, n, 5, "unexpected length of received data")
 		assert.Equal(t, ppi, PayloadProtocolIdentifier(0), "unexpected ppi")
 
 		assert.False(t, s0.reassemblyQueue.isReadable(), "should no longer be readable")

--- a/stream.go
+++ b/stream.go
@@ -138,15 +138,12 @@ func (s *Stream) ReadSCTP(payload []byte) (int, PayloadProtocolIdentifier, error
 
 	for {
 		n, ppi, err := s.reassemblyQueue.read(payload)
-		if err == nil {
-			return n, ppi, nil
-		} else if errors.Is(err, io.ErrShortBuffer) {
-			return 0, PayloadProtocolIdentifier(0), err
+		if err == nil || errors.Is(err, io.ErrShortBuffer) {
+			return n, ppi, err
 		}
 
-		err = s.readErr
-		if err != nil {
-			return 0, PayloadProtocolIdentifier(0), err
+		if s.readErr != nil {
+			return 0, PayloadProtocolIdentifier(0), s.readErr
 		}
 
 		s.readNotifier.Wait()


### PR DESCRIPTION
Currently if the user passes a buffer to read into that is shorter then the current message we lose the buffer. This PR changes the behavior to instead keep what's in the reassemblyQueue until it can be read.

Relates to pion/webrtc#2712
