### PR TITLE
Enforce testify/assert for tests

### DIFF
--- a/ack_timer_test.go
+++ b/ack_timer_test.go
@@ -45,7 +45,7 @@ func TestAckTimer(t *testing.T) {
 			// Sleep more than 2 * 200msec interval to test if it times out only once
 			time.Sleep(ackInterval*2 + 50*time.Millisecond)
 
-			assert.Equal(t, uint32(1), atomic.LoadUint32(&nCbs),
+			assert.Equalf(t, uint32(1), atomic.LoadUint32(&nCbs),
 				"should be called once (actual: %d)", atomic.LoadUint32(&nCbs))
 
 			atomic.StoreUint32(&nCbs, 0)
@@ -84,7 +84,7 @@ func TestAckTimer(t *testing.T) {
 		// Sleep more than 200msec of interval to test if it never times out
 		time.Sleep(ackInterval + 50*time.Millisecond)
 
-		assert.Equal(t, uint32(0), atomic.LoadUint32(&nCbs),
+		assert.Equalf(t, uint32(0), atomic.LoadUint32(&nCbs),
 			"should not be timed out (actual: %d)", atomic.LoadUint32(&nCbs))
 
 		// can start again

--- a/chunk_forward_tsn_test.go
+++ b/chunk_forward_tsn_test.go
@@ -25,15 +25,11 @@ func TestChunkForwardTSN_Success(t *testing.T) {
 	for i, tc := range tt {
 		actual := &chunkForwardTSN{}
 		err := actual.unmarshal(tc.binary)
-		if err != nil {
-			t.Fatalf("failed to unmarshal #%d: %v", i, err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshal #%d", i)
 
 		b, err := actual.marshal()
-		if err != nil {
-			t.Fatalf("failed to marshal: %v", err)
-		}
-		assert.Equal(t, tc.binary, b, "test %d not equal", i)
+		assert.NoError(t, err)
+		assert.Equalf(t, tc.binary, b, "test %d not equal", i)
 	}
 }
 
@@ -50,8 +46,6 @@ func TestChunkForwardTSNUnmarshal_Failure(t *testing.T) {
 	for i, tc := range tt {
 		actual := &chunkForwardTSN{}
 		err := actual.unmarshal(tc.binary)
-		if err == nil {
-			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
-		}
+		assert.Errorf(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
 	}
 }

--- a/chunk_init_test.go
+++ b/chunk_init_test.go
@@ -5,6 +5,8 @@ package sctp
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestChunkInit_UnrecognizedParameters(t *testing.T) {
@@ -17,21 +19,15 @@ func TestChunkInit_UnrecognizedParameters(t *testing.T) {
 	unrecognizedSkip = append(unrecognizedSkip, byte(paramHeaderUnrecognizedActionSkip), 0xFF, 0x00, 0x04, 0x00)
 
 	initCommonChunk := &chunkInitCommon{}
-	if err := initCommonChunk.unmarshal(unrecognizedSkip); err != nil {
-		t.Errorf("Unmarshal init Chunk failed: %v", err)
-	} else if len(initCommonChunk.unrecognizedParams) != 1 ||
-		initCommonChunk.unrecognizedParams[0].unrecognizedAction != paramHeaderUnrecognizedActionSkip {
-		t.Errorf("Unrecognized Param parsed incorrectly")
-	}
+	assert.NoError(t, initCommonChunk.unmarshal(unrecognizedSkip))
+	assert.Equal(t, 1, len(initCommonChunk.unrecognizedParams))
+	assert.Equal(t, paramHeaderUnrecognizedActionSkip, initCommonChunk.unrecognizedParams[0].unrecognizedAction)
 
 	unrecognizedStop := append([]byte{}, initChunkHeader...)
 	unrecognizedStop = append(unrecognizedStop, byte(paramHeaderUnrecognizedActionStop), 0xFF, 0x00, 0x04, 0x00)
 
 	initCommonChunk = &chunkInitCommon{}
-	if err := initCommonChunk.unmarshal(unrecognizedStop); err != nil {
-		t.Errorf("Unmarshal init Chunk failed: %v", err)
-	} else if len(initCommonChunk.unrecognizedParams) != 1 ||
-		initCommonChunk.unrecognizedParams[0].unrecognizedAction != paramHeaderUnrecognizedActionStop {
-		t.Errorf("Unrecognized Param parsed incorrectly")
-	}
+	assert.NoError(t, initCommonChunk.unmarshal(unrecognizedStop))
+	assert.Equal(t, 1, len(initCommonChunk.unrecognizedParams))
+	assert.Equal(t, paramHeaderUnrecognizedActionStop, initCommonChunk.unrecognizedParams[0].unrecognizedAction)
 }

--- a/chunk_reconfig_test.go
+++ b/chunk_reconfig_test.go
@@ -39,15 +39,11 @@ func TestChunkReconfig_Success(t *testing.T) {
 	for i, tc := range tt {
 		actual := &chunkReconfig{}
 		err := actual.unmarshal(tc.binary)
-		if err != nil {
-			t.Fatalf("failed to unmarshal #%d: %v", i, err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshal #%d: %v", i)
 
 		b, err := actual.marshal()
-		if err != nil {
-			t.Fatalf("failed to marshal: %v", err)
-		}
-		assert.Equal(t, tc.binary, b, "test %d not equal", i)
+		assert.NoError(t, err)
+		assert.Equalf(t, tc.binary, b, "test %d not equal", i)
 	}
 }
 
@@ -70,8 +66,6 @@ func TestChunkReconfigUnmarshal_Failure(t *testing.T) {
 	for i, tc := range tt {
 		actual := &chunkReconfig{}
 		err := actual.unmarshal(tc.binary)
-		if err == nil {
-			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
-		}
+		assert.Errorf(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
 	}
 }

--- a/chunk_shutdown_ack_test.go
+++ b/chunk_shutdown_ack_test.go
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
+//nolint:dupl
 package sctp
 
 import (
@@ -20,11 +21,11 @@ func TestChunkShutdownAck_Success(t *testing.T) {
 	for i, tc := range tt {
 		actual := &chunkShutdownAck{}
 		err := actual.unmarshal(tc.binary)
-		require.NoError(t, err, "failed to unmarshal #%d: %v", i, err)
+		require.NoErrorf(t, err, "failed to unmarshal #%d", i)
 
 		b, err := actual.marshal()
-		require.NoError(t, err, "failed to marshal: %v", err)
-		assert.Equal(t, tc.binary, b, "test %d not equal", i)
+		require.NoError(t, err)
+		assert.Equalf(t, tc.binary, b, "test %d not equal", i)
 	}
 }
 
@@ -41,8 +42,6 @@ func TestChunkShutdownAck_Failure(t *testing.T) {
 	for i, tc := range tt {
 		actual := &chunkShutdownAck{}
 		err := actual.unmarshal(tc.binary)
-		if err == nil {
-			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
-		}
+		assert.Errorf(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
 	}
 }

--- a/chunk_shutdown_complete_test.go
+++ b/chunk_shutdown_complete_test.go
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
+//nolint:dupl
 package sctp
 
 import (
@@ -20,15 +21,15 @@ func TestChunkShutdownComplete_Success(t *testing.T) {
 	for i, tc := range tt {
 		actual := &chunkShutdownComplete{}
 		err := actual.unmarshal(tc.binary)
-		require.NoError(t, err, "failed to unmarshal #%d: %v", i, err)
+		require.NoErrorf(t, err, "failed to unmarshal #%d", i)
 
 		b, err := actual.marshal()
-		require.NoError(t, err, "failed to marshal: %v", err)
-		assert.Equal(t, tc.binary, b, "test %d not equal", i)
+		require.NoError(t, err)
+		assert.Equalf(t, tc.binary, b, "test %d not equal", i)
 	}
 }
 
-func TestChunkShutdownComplete_Failure(t *testing.T) {
+func TestChunkShutdownComplete_Failure(t *testing.T) { //nolint:dupl
 	tt := []struct {
 		name   string
 		binary []byte
@@ -41,6 +42,6 @@ func TestChunkShutdownComplete_Failure(t *testing.T) {
 	for i, tc := range tt {
 		actual := &chunkShutdownComplete{}
 		err := actual.unmarshal(tc.binary)
-		require.Error(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
+		require.Errorf(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
 	}
 }

--- a/chunk_shutdown_test.go
+++ b/chunk_shutdown_test.go
@@ -19,15 +19,11 @@ func TestChunkShutdown_Success(t *testing.T) {
 	for i, tc := range tt {
 		actual := &chunkShutdown{}
 		err := actual.unmarshal(tc.binary)
-		if err != nil {
-			t.Fatalf("failed to unmarshal #%d: %v", i, err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshal #%d: %v", i)
 
 		b, err := actual.marshal()
-		if err != nil {
-			t.Fatalf("failed to marshal: %v", err)
-		}
-		assert.Equal(t, tc.binary, b, "test %d not equal", i)
+		assert.NoError(t, err)
+		assert.Equalf(t, tc.binary, b, "test %d not equal", i)
 	}
 }
 
@@ -46,8 +42,6 @@ func TestChunkShutdown_Failure(t *testing.T) {
 	for i, tc := range tt {
 		actual := &chunkShutdown{}
 		err := actual.unmarshal(tc.binary)
-		if err == nil {
-			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
-		}
+		assert.Errorf(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
 	}
 }

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -25,39 +25,24 @@ func TestInitChunk(t *testing.T) {
 	}
 
 	initChunk, ok := pkt.chunks[0].(*chunkInit)
-	if !ok {
-		t.Errorf("Failed to cast Chunk -> Init")
-	}
+	assert.True(t, ok, "Failed to cast Chunk -> Init")
 
-	switch {
-	case err != nil:
-		t.Errorf("Unmarshal init Chunk failed: %v", err)
-	case initChunk.initiateTag != 1438213285:
-		t.Errorf(
-			"Unmarshal passed for SCTP packet, but got incorrect initiate tag exp: %d act: %d",
-			1438213285, initChunk.initiateTag,
-		)
-	case initChunk.advertisedReceiverWindowCredit != 131072:
-		t.Errorf(
-			"Unmarshal passed for SCTP packet, but got incorrect advertisedReceiverWindowCredit exp: %d act: %d",
-			131072, initChunk.advertisedReceiverWindowCredit,
-		)
-	case initChunk.numOutboundStreams != 1024:
-		t.Errorf(
-			"Unmarshal passed for SCTP packet, but got incorrect numOutboundStreams tag exp: %d act: %d",
-			1024, initChunk.numOutboundStreams,
-		)
-	case initChunk.numInboundStreams != 2048:
-		t.Errorf(
-			"Unmarshal passed for SCTP packet, but got incorrect numInboundStreams exp: %d act: %d",
-			2048, initChunk.numInboundStreams,
-		)
-	case initChunk.initialTSN != uint32(3899461680):
-		t.Errorf(
-			"Unmarshal passed for SCTP packet, but got incorrect initialTSN exp: %d act: %d",
-			uint32(3899461680), initChunk.initialTSN,
-		)
-	}
+	assert.NoError(t, err, "Unmarshal init Chunk failed")
+	assert.Equalf(t, initChunk.initiateTag, uint32(1438213285),
+		"Unmarshal passed for SCTP packet, but got incorrect initiate tag exp: %d act: %d",
+		1438213285, initChunk.initiateTag)
+	assert.Equalf(t, initChunk.advertisedReceiverWindowCredit, uint32(131072),
+		"Unmarshal passed for SCTP packet, but got incorrect advertisedReceiverWindowCredit exp: %d act: %d",
+		131072, initChunk.advertisedReceiverWindowCredit)
+	assert.Equalf(t, initChunk.numOutboundStreams, uint16(1024),
+		"Unmarshal passed for SCTP packet, but got incorrect numOutboundStreams tag exp: %d act: %d",
+		1024, initChunk.numOutboundStreams)
+	assert.Equalf(t, initChunk.numInboundStreams, uint16(2048),
+		"Unmarshal passed for SCTP packet, but got incorrect numInboundStreams exp: %d act: %d",
+		2048, initChunk.numInboundStreams)
+	assert.Equalf(t, initChunk.initialTSN, uint32(3899461680),
+		"Unmarshal passed for SCTP packet, but got incorrect initialTSN exp: %d act: %d",
+		3899461680, initChunk.initialTSN)
 }
 
 func TestInitAck(t *testing.T) {
@@ -68,16 +53,11 @@ func TestInitAck(t *testing.T) {
 		0x94, 0x06, 0x2f, 0x93,
 	}
 	err := pkt.unmarshal(true, rawPkt)
-	if err != nil {
-		t.Errorf("Unmarshal failed, has chunk: %v", err)
-	}
+	assert.NoError(t, err)
 
 	_, ok := pkt.chunks[0].(*chunkInitAck)
-	if !ok {
-		t.Error("Failed to cast Chunk -> Init")
-	} else if err != nil {
-		t.Errorf("Unmarshal init Chunk failed: %v", err)
-	}
+	assert.True(t, ok, "Failed to cast Chunk -> InitAck")
+	assert.NoError(t, err)
 }
 
 func TestChromeChunk1Init(t *testing.T) {
@@ -91,14 +71,10 @@ func TestChromeChunk1Init(t *testing.T) {
 		0x00, 0x00, 0x80, 0x03, 0x00, 0x06, 0x80, 0xc1, 0x00, 0x00,
 	}
 	err := pkt.unmarshal(true, rawPkt)
-	if err != nil {
-		t.Errorf("Unmarshal failed, has chunk: %v", err)
-	}
+	assert.NoError(t, err)
 
 	rawPkt2, err := pkt.marshal(true)
-	if err != nil {
-		t.Errorf("Remarshal failed: %v", err)
-	}
+	assert.NoError(t, err)
 
 	assert.Equal(t, rawPkt, rawPkt2)
 }
@@ -131,19 +107,15 @@ func TestChromeChunk2InitAck(t *testing.T) {
 		0xce, 0xf4, 0xfc, 0xb3, 0x66, 0x99, 0x4f, 0xdb, 0x4f, 0x95, 0x6b, 0x6f, 0x3b, 0xb1, 0xdb, 0x5a,
 	}
 	err := pkt.unmarshal(true, rawPkt)
-	if err != nil {
-		t.Errorf("Unmarshal failed, has chunk: %v", err)
-	}
+	assert.NoError(t, err)
 
 	rawPkt2, err := pkt.marshal(true)
-	if err != nil {
-		t.Errorf("Remarshal failed: %v", err)
-	}
+	assert.NoError(t, err)
 
 	assert.Equal(t, rawPkt, rawPkt2)
 }
 
-func TestInitMarshalUnmarshal(t *testing.T) { //nolint:cyclop
+func TestInitMarshalUnmarshal(t *testing.T) {
 	sctpPacket := &packet{}
 	sctpPacket.destinationPort = 1
 	sctpPacket.sourcePort = 1
@@ -157,57 +129,37 @@ func TestInitMarshalUnmarshal(t *testing.T) { //nolint:cyclop
 	initAck.initiateTag = 123
 	initAck.advertisedReceiverWindowCredit = 1024
 	cookie, ErrRand := newRandomStateCookie()
-	if ErrRand != nil {
-		t.Fatalf("Failed to generate random state cookie: %v", ErrRand)
-	}
+	assert.NoError(t, ErrRand, "Failed to generate random state cookie")
+
 	initAck.params = []param{cookie}
 
 	sctpPacket.chunks = []chunk{initAck}
 	rawPkt, err := sctpPacket.marshal(true)
-	if err != nil {
-		t.Errorf("Failed to marshal packet: %v", err)
-	}
+	assert.NoError(t, err)
 
 	pkt := &packet{}
 	err = pkt.unmarshal(true, rawPkt)
-	if err != nil {
-		t.Errorf("Unmarshal failed, has chunk: %v", err)
-	}
+	assert.NoError(t, err)
 
 	initAckChunk, ok := pkt.chunks[0].(*chunkInitAck)
-	if !ok {
-		t.Error("Failed to cast Chunk -> InitAck")
-	}
+	assert.True(t, ok, "Failed to cast Chunk -> InitAck")
 
-	switch {
-	case err != nil:
-		t.Errorf("Unmarshal init ack Chunk failed: %v", err)
-	case initAckChunk.initiateTag != 123:
-		t.Errorf(
-			"Unmarshal passed for SCTP packet, but got incorrect initiate tag exp: %d act: %d",
-			123, initAckChunk.initiateTag,
-		)
-	case initAckChunk.advertisedReceiverWindowCredit != 1024:
-		t.Errorf(
-			"Unmarshal passed for SCTP packet, but got incorrect advertisedReceiverWindowCredit exp: %d act: %d",
-			1024, initAckChunk.advertisedReceiverWindowCredit,
-		)
-	case initAckChunk.numOutboundStreams != 1:
-		t.Errorf(
-			"Unmarshal passed for SCTP packet, but got incorrect numOutboundStreams tag exp: %d act: %d",
-			1, initAckChunk.numOutboundStreams,
-		)
-	case initAckChunk.numInboundStreams != 1:
-		t.Errorf(
-			"Unmarshal passed for SCTP packet, but got incorrect numInboundStreams exp: %d act: %d",
-			1, initAckChunk.numInboundStreams,
-		)
-	case initAckChunk.initialTSN != 123:
-		t.Errorf(
-			"Unmarshal passed for SCTP packet, but got incorrect initialTSN exp: %d act: %d",
-			123, initAckChunk.initialTSN,
-		)
-	}
+	assert.NoError(t, err, "Unmarshal init ack Chunk failed")
+	assert.Equalf(t, initAckChunk.initiateTag, uint32(123),
+		"Unmarshal passed for SCTP packet, but got incorrect initiate tag exp: %d act: %d",
+		123, initAckChunk.initiateTag)
+	assert.Equalf(t, initAckChunk.advertisedReceiverWindowCredit, uint32(1024),
+		"Unmarshal passed for SCTP packet, but got incorrect advertisedReceiverWindowCredit exp: %d act: %d",
+		1024, initAckChunk.advertisedReceiverWindowCredit)
+	assert.Equalf(t, initAckChunk.numOutboundStreams, uint16(1),
+		"Unmarshal passed for SCTP packet, but got incorrect numOutboundStreams tag exp: %d act: %d",
+		1, initAckChunk.numOutboundStreams)
+	assert.Equalf(t, initAckChunk.numInboundStreams, uint16(1),
+		"Unmarshal passed for SCTP packet, but got incorrect numInboundStreams exp: %d act: %d",
+		1, initAckChunk.numInboundStreams)
+	assert.Equalf(t, initAckChunk.initialTSN, uint32(123),
+		"Unmarshal passed for SCTP packet, but got incorrect initialTSN exp: %d act: %d",
+		123, initAckChunk.initialTSN)
 }
 
 func TestPayloadDataMarshalUnmarshal(t *testing.T) {
@@ -220,14 +172,10 @@ func TestPayloadDataMarshalUnmarshal(t *testing.T) {
 		0x00, 0x03, 0x00, 0x00, 0x66, 0x6f, 0x6f, 0x00,
 	}
 	err := pkt.unmarshal(true, rawPkt)
-	if err != nil {
-		t.Errorf("Unmarshal failed, has chunk: %v", err)
-	}
+	assert.NoError(t, err)
 
 	_, ok := pkt.chunks[1].(*chunkPayloadData)
-	if !ok {
-		t.Error("Failed to cast Chunk -> PayloadData")
-	}
+	assert.True(t, ok, "Failed to cast Chunk -> PayloadData")
 }
 
 func TestSelectAckChunk(t *testing.T) {
@@ -238,14 +186,10 @@ func TestSelectAckChunk(t *testing.T) {
 		0xfe, 0x74, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x02,
 	}
 	err := pkt.unmarshal(true, rawPkt)
-	if err != nil {
-		t.Errorf("Unmarshal failed, has chunk: %v", err)
-	}
+	assert.NoError(t, err)
 
 	_, ok := pkt.chunks[0].(*chunkSelectiveAck)
-	if !ok {
-		t.Error("Failed to cast Chunk -> SelectiveAck")
-	}
+	assert.True(t, ok, "Failed to cast Chunk -> SelectiveAck")
 }
 
 func TestReconfigChunk(t *testing.T) {
@@ -256,21 +200,13 @@ func TestReconfigChunk(t *testing.T) {
 		0xff, 0x4e, 0x1c, 0xb9, 0xe6, 0x0, 0x1, 0x0, 0x0,
 	}
 	err := pkt.unmarshal(true, rawPkt)
-	if err != nil {
-		t.Errorf("Unmarshal failed, has chunk: %v", err)
-	}
+	assert.NoError(t, err)
 
 	c, ok := pkt.chunks[0].(*chunkReconfig)
-	if !ok {
-		t.Error("Failed to cast Chunk -> Reconfig")
-	}
+	assert.True(t, ok, "Failed to cast Chunk -> Reconfig")
 
-	if c.paramA.(*paramOutgoingResetRequest).streamIdentifiers[0] != uint16(1) { //nolint:forcetypeassert
-		t.Errorf(
-			"unexpected stream identifier: %d",
-			c.paramA.(*paramOutgoingResetRequest).streamIdentifiers[0], //nolint:forcetypeassert
-		)
-	}
+	iden := c.paramA.(*paramOutgoingResetRequest).streamIdentifiers[0] //nolint:forcetypeassert
+	assert.Equalf(t, iden, uint16(1), "unexpected stream identifier: %d", iden)
 }
 
 func TestForwardTSNChunk(t *testing.T) {
@@ -280,16 +216,9 @@ func TestForwardTSNChunk(t *testing.T) {
 		testChunkForwardTSN()...,
 	)
 	err := pkt.unmarshal(true, rawPkt)
-	if err != nil {
-		t.Errorf("Unmarshal failed, has chunk: %v", err)
-	}
+	assert.NoError(t, err)
 
 	c, ok := pkt.chunks[0].(*chunkForwardTSN)
-	if !ok {
-		t.Error("Failed to cast Chunk -> Forward TSN")
-	}
-
-	if c.newCumulativeTSN != uint32(3) {
-		t.Errorf("unexpected New Cumulative TSN: %d", c.newCumulativeTSN)
-	}
+	assert.True(t, ok, "Failed to cast Chunk -> Forward TSN")
+	assert.Equalf(t, c.newCumulativeTSN, uint32(3), "unexpected New Cumulative TSN")
 }

--- a/chunktype_test.go
+++ b/chunktype_test.go
@@ -3,7 +3,11 @@
 
 package sctp
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestChunkType_String(t *testing.T) {
 	tt := []struct {
@@ -30,8 +34,6 @@ func TestChunkType_String(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		if tc.chunkType.String() != tc.expected {
-			t.Errorf("failed to stringify chunkType %v, expected %s", tc.chunkType, tc.expected)
-		}
+		assert.Equalf(t, tc.expected, tc.chunkType.String(), "chunkType %v should be %s", tc.chunkType, tc.expected)
 	}
 }

--- a/param_ecn_capable_test.go
+++ b/param_ecn_capable_test.go
@@ -34,14 +34,11 @@ func TestParamECNCapabale_Success(t *testing.T) {
 	for i, tc := range tt {
 		actual := &paramECNCapable{}
 		_, err := actual.unmarshal(tc.binary)
-		if err != nil {
-			t.Fatalf("failed to unmarshal #%d: %v", i, err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshal #%d", i)
 		assert.Equal(t, tc.parsed, actual)
+
 		b, err := actual.marshal()
-		if err != nil {
-			t.Fatalf("failed to marshal: %v", err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshal #%d", i)
 		assert.Equal(t, tc.binary, b)
 	}
 }
@@ -57,8 +54,6 @@ func TestParamECNCapabale_Failure(t *testing.T) {
 	for i, tc := range tt {
 		actual := &paramECNCapable{}
 		_, err := actual.unmarshal(tc.binary)
-		if err == nil {
-			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
-		}
+		assert.Errorf(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
 	}
 }

--- a/param_forward_tsn_supported_test.go
+++ b/param_forward_tsn_supported_test.go
@@ -34,14 +34,11 @@ func TestParamForwardTSNSupported_Success(t *testing.T) {
 	for i, tc := range tt {
 		actual := &paramForwardTSNSupported{}
 		_, err := actual.unmarshal(tc.binary)
-		if err != nil {
-			t.Fatalf("failed to unmarshal #%d: %v", i, err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshal #%d", i)
 		assert.Equal(t, tc.parsed, actual)
+
 		b, err := actual.marshal()
-		if err != nil {
-			t.Fatalf("failed to marshal: %v", err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshal #%d", i)
 		assert.Equal(t, tc.binary, b)
 	}
 }
@@ -57,8 +54,6 @@ func TestParamForwardTSNSupported_Failure(t *testing.T) {
 	for i, tc := range tt {
 		actual := &paramForwardTSNSupported{}
 		_, err := actual.unmarshal(tc.binary)
-		if err == nil {
-			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
-		}
+		assert.Errorf(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
 	}
 }

--- a/param_outgoing_reset_request_test.go
+++ b/param_outgoing_reset_request_test.go
@@ -58,14 +58,11 @@ func TestParamOutgoingResetRequest_Success(t *testing.T) {
 	for i, tc := range tt {
 		actual := &paramOutgoingResetRequest{}
 		_, err := actual.unmarshal(tc.binary)
-		if err != nil {
-			t.Fatalf("failed to unmarshal #%d: %v", i, err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshal #%d", i)
 		assert.Equal(t, tc.parsed, actual)
+
 		b, err := actual.marshal()
-		if err != nil {
-			t.Fatalf("failed to marshal: %v", err)
-		}
+		assert.NoErrorf(t, err, "failed to marshal #%d", i)
 		assert.Equal(t, tc.binary, b)
 	}
 }
@@ -82,8 +79,6 @@ func TestParamOutgoingResetRequest_Failure(t *testing.T) {
 	for i, tc := range tt {
 		actual := &paramOutgoingResetRequest{}
 		_, err := actual.unmarshal(tc.binary)
-		if err == nil {
-			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
-		}
+		assert.Errorf(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
 	}
 }

--- a/param_reconfig_response_test.go
+++ b/param_reconfig_response_test.go
@@ -35,14 +35,11 @@ func TestParamReconfigResponse_Success(t *testing.T) {
 	for i, tc := range tt {
 		actual := &paramReconfigResponse{}
 		_, err := actual.unmarshal(tc.binary)
-		if err != nil {
-			t.Fatalf("failed to unmarshal #%d: %v", i, err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshal #%d: %v", i)
 		assert.Equal(t, tc.parsed, actual)
+
 		b, err := actual.marshal()
-		if err != nil {
-			t.Fatalf("failed to marshal: %v", err)
-		}
+		assert.NoErrorf(t, err, "failed to marshal #%d: %v", i)
 		assert.Equal(t, tc.binary, b)
 	}
 }
@@ -59,9 +56,7 @@ func TestParamReconfigResponse_Failure(t *testing.T) {
 	for i, tc := range tt {
 		actual := &paramReconfigResponse{}
 		_, err := actual.unmarshal(tc.binary)
-		if err == nil {
-			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
-		}
+		assert.Errorf(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
 	}
 }
 
@@ -81,6 +76,6 @@ func TestReconfigResultStringer(t *testing.T) {
 
 	for i, tc := range tt {
 		actual := tc.result.String()
-		assert.Equal(t, tc.expected, actual, "Test case %d", i)
+		assert.Equalf(t, tc.expected, actual, "Test case %d", i)
 	}
 }

--- a/param_test.go
+++ b/param_test.go
@@ -18,17 +18,13 @@ func TestBuildParam_Success(t *testing.T) {
 
 	for i, tc := range tt {
 		pType, err := parseParamType(tc.binary)
-		if err != nil {
-			t.Fatalf("failed to parse param type: %v", err)
-		}
+		assert.NoErrorf(t, err, "failed to parse param type #%d", i)
+
 		p, err := buildParam(pType, tc.binary)
-		if err != nil {
-			t.Fatalf("failed to unmarshal #%d: %v", i, err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshal #%d", i)
+
 		b, err := p.marshal()
-		if err != nil {
-			t.Fatalf("failed to marshal: %v", err)
-		}
+		assert.NoErrorf(t, err, "failed to marshal #%d", i)
 		assert.Equal(t, tc.binary, b)
 	}
 }
@@ -44,12 +40,9 @@ func TestBuildParam_Failure(t *testing.T) {
 
 	for i, tc := range tt {
 		pType, err := parseParamType(tc.binary)
-		if err != nil {
-			t.Fatalf("failed to parse param type: %v", err)
-		}
+		assert.NoErrorf(t, err, "failed to parse param type #%d", i)
+
 		_, err = buildParam(pType, tc.binary)
-		if err == nil {
-			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
-		}
+		assert.Errorf(t, err, "expected buildParam #%d: '%s' to fail.", i, tc.name)
 	}
 }

--- a/paramheader_test.go
+++ b/paramheader_test.go
@@ -31,14 +31,11 @@ func TestParamHeader_Success(t *testing.T) {
 	for i, tc := range tt {
 		actual := &paramHeader{}
 		err := actual.unmarshal(tc.binary)
-		if err != nil {
-			t.Errorf("failed to unmarshal #%d: %v", i, err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshal #%d", i)
 		assert.Equal(t, tc.parsed, actual)
+
 		b, err := actual.marshal()
-		if err != nil {
-			t.Errorf("failed to marshal: %v", err)
-		}
+		assert.NoErrorf(t, err, "failed to marshal #%d", i)
 		assert.Equal(t, tc.binary, b)
 	}
 }
@@ -57,8 +54,6 @@ func TestParamHeaderUnmarshal_Failure(t *testing.T) {
 	for i, tc := range tt {
 		actual := &paramHeader{}
 		err := actual.unmarshal(tc.binary)
-		if err == nil {
-			t.Errorf("expected unmarshal #%d: '%s' to fail.", i, tc.name)
-		}
+		assert.Errorf(t, err, "expected unmarshal #%d: '%s' to fail.", i, tc.name)
 	}
 }

--- a/paramtype_test.go
+++ b/paramtype_test.go
@@ -20,9 +20,7 @@ func TestParseParamType_Success(t *testing.T) {
 
 	for i, tc := range tt {
 		pType, err := parseParamType(tc.binary)
-		if err != nil {
-			t.Fatalf("failed to parse paramType %d: %v", i, err)
-		}
+		assert.NoErrorf(t, err, "failed to parse paramType #%d", i)
 		assert.Equal(t, tc.expected, pType)
 	}
 }
@@ -37,8 +35,6 @@ func TestParseParamType_Failure(t *testing.T) {
 
 	for i, tc := range tt {
 		_, err := parseParamType(tc.binary)
-		if err == nil {
-			t.Errorf("expected parseParamType #%d: '%s' to fail.", i, tc.name)
-		}
+		assert.Errorf(t, err, "expected parseParamType #%d: '%s' to fail.", i, tc.name)
 	}
 }

--- a/payload_queue_test.go
+++ b/payload_queue_test.go
@@ -29,9 +29,7 @@ func TestPayloadQueue(t *testing.T) {
 		for i := uint32(0); i < 3; i++ {
 			c, ok := pq.pop(i)
 			assert.True(t, ok, "pop should succeed")
-			if ok {
-				assert.Equal(t, i, c.tsn, "TSN should match")
-			}
+			assert.Equal(t, i, c.tsn, "TSN should match")
 		}
 
 		assert.Equal(t, 0, pq.getNumBytes(), "total bytes mismatch")
@@ -45,9 +43,7 @@ func TestPayloadQueue(t *testing.T) {
 		for i := uint32(3); i < 5; i++ {
 			c, ok := pq.pop(i)
 			assert.True(t, ok, "pop should succeed")
-			if ok {
-				assert.Equal(t, i, c.tsn, "TSN should match")
-			}
+			assert.Equal(t, i, c.tsn, "TSN should match")
 		}
 
 		assert.Equal(t, 0, pq.getNumBytes(), "total bytes mismatch")

--- a/receive_payload_queue_test.go
+++ b/receive_payload_queue_test.go
@@ -30,7 +30,7 @@ func TestReceivePayloadQueue(t *testing.T) {
 	assert.True(t, payloadQueue.push(nextTSN))
 	assert.Equal(t, 1, payloadQueue.size())
 	lastTSN, ok := payloadQueue.getLastTSNReceived()
-	assert.True(t, lastTSN == nextTSN && ok, "lastTSN:%d, ok:%t", lastTSN, ok)
+	assert.Truef(t, lastTSN == nextTSN && ok, "lastTSN:%d, ok:%t", lastTSN, ok)
 	assert.True(t, payloadQueue.hasChunk(nextTSN))
 
 	assert.True(t, payloadQueue.push(initTSN))

--- a/rtx_timer_test.go
+++ b/rtx_timer_test.go
@@ -126,7 +126,7 @@ func TestRtxTimer(t *testing.T) { //nolint:maintidx
 				// 60 : 2 (90)
 				// 120: 3 (210)
 				// 240: 4 (550) <== expected in 650 msec
-				assert.Equal(t, timerID, id, "unexpted timer ID: %d", id)
+				assert.Equalf(t, timerID, id, "unexpted timer ID: %d", id)
 			},
 			onRtxFailure: func(_ int) {},
 		}, pathMaxRetrans, 0)
@@ -152,7 +152,7 @@ func TestRtxTimer(t *testing.T) { //nolint:maintidx
 		rt := newRTXTimer(timerID, &testTimerObserver{
 			onRTO: func(id int, _ uint) {
 				atomic.AddInt32(&nCbs, 1)
-				assert.Equal(t, timerID, id, "unexpted timer ID: %d", id)
+				assert.Equalf(t, timerID, id, "unexpted timer ID: %d", id)
 			},
 			onRtxFailure: func(_ int) {},
 		}, pathMaxRetrans, 0)
@@ -179,7 +179,7 @@ func TestRtxTimer(t *testing.T) { //nolint:maintidx
 		rt := newRTXTimer(timerID, &testTimerObserver{
 			onRTO: func(id int, _ uint) {
 				atomic.AddInt32(&nCbs, 1)
-				assert.Equal(t, timerID, id, "unexpted timer ID: %d", id)
+				assert.Equalf(t, timerID, id, "unexpted timer ID: %d", id)
 			},
 			onRtxFailure: func(_ int) {},
 		}, pathMaxRetrans, 0)
@@ -202,7 +202,7 @@ func TestRtxTimer(t *testing.T) { //nolint:maintidx
 		rt := newRTXTimer(timerID, &testTimerObserver{
 			onRTO: func(id int, _ uint) {
 				atomic.AddInt32(&nCbs, 1)
-				assert.Equal(t, timerID, id, "unexpted timer ID: %d", id)
+				assert.Equalf(t, timerID, id, "unexpted timer ID: %d", id)
 			},
 			onRtxFailure: func(_ int) {},
 		}, pathMaxRetrans, 0)
@@ -229,7 +229,7 @@ func TestRtxTimer(t *testing.T) { //nolint:maintidx
 			onRTO: func(id int, _ uint) {
 				atomic.AddInt32(&nCbs, 1)
 				t.Log("onRTO() called")
-				assert.Equal(t, timerID, id, "unexpted timer ID: %d", id)
+				assert.Equalf(t, timerID, id, "unexpted timer ID: %d", id)
 			},
 			onRtxFailure: func(_ int) {},
 		}, pathMaxRetrans, 0)

--- a/util_test.go
+++ b/util_test.go
@@ -25,7 +25,7 @@ func TestPadByte_Success(t *testing.T) {
 	for i, tc := range tt {
 		actual := padByte(tc.value, tc.padLen)
 
-		assert.Equal(t, tc.expected, actual, "test %d not equal", i)
+		assert.Equalf(t, tc.expected, actual, "test %d not equal", i)
 	}
 }
 
@@ -43,28 +43,28 @@ func TestSerialNumberArithmetic(t *testing.T) {
 			s2f := s1 + maxForwardDistance
 			s2b := s1 + maxBackwardDistance
 
-			assert.True(t, sna32LT(s1, s2f), "s1 < s2 should be true: s1=0x%x s2=0x%x", s1, s2f)
-			assert.False(t, sna32LT(s1, s2b), "s1 < s2 should be false: s1=0x%x s2=0x%x", s1, s2b)
+			assert.Truef(t, sna32LT(s1, s2f), "s1 < s2 should be true: s1=0x%x s2=0x%x", s1, s2f)
+			assert.Falsef(t, sna32LT(s1, s2b), "s1 < s2 should be false: s1=0x%x s2=0x%x", s1, s2b)
 
-			assert.False(t, sna32GT(s1, s2f), "s1 > s2 should be fales: s1=0x%x s2=0x%x", s1, s2f)
-			assert.True(t, sna32GT(s1, s2b), "s1 > s2 should be true: s1=0x%x s2=0x%x", s1, s2b)
+			assert.Falsef(t, sna32GT(s1, s2f), "s1 > s2 should be fales: s1=0x%x s2=0x%x", s1, s2f)
+			assert.Truef(t, sna32GT(s1, s2b), "s1 > s2 should be true: s1=0x%x s2=0x%x", s1, s2b)
 
-			assert.True(t, sna32LTE(s1, s2f), "s1 <= s2 should be true: s1=0x%x s2=0x%x", s1, s2f)
-			assert.False(t, sna32LTE(s1, s2b), "s1 <= s2 should be false: s1=0x%x s2=0x%x", s1, s2b)
+			assert.Truef(t, sna32LTE(s1, s2f), "s1 <= s2 should be true: s1=0x%x s2=0x%x", s1, s2f)
+			assert.Falsef(t, sna32LTE(s1, s2b), "s1 <= s2 should be false: s1=0x%x s2=0x%x", s1, s2b)
 
-			assert.False(t, sna32GTE(s1, s2f), "s1 >= s2 should be fales: s1=0x%x s2=0x%x", s1, s2f)
-			assert.True(t, sna32GTE(s1, s2b), "s1 >= s2 should be true: s1=0x%x s2=0x%x", s1, s2b)
+			assert.Falsef(t, sna32GTE(s1, s2f), "s1 >= s2 should be fales: s1=0x%x s2=0x%x", s1, s2f)
+			assert.Truef(t, sna32GTE(s1, s2b), "s1 >= s2 should be true: s1=0x%x s2=0x%x", s1, s2b)
 
-			assert.True(t, sna32EQ(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
-			assert.True(t, sna32EQ(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
-			assert.False(t, sna32EQ(s1, s1+1), "s1 == s1+1 should be false: s1=0x%x s1+1=0x%x", s1, s1+1)
-			assert.False(t, sna32EQ(s1, s1-1), "s1 == s1-1 hould be false: s1=0x%x s1-1=0x%x", s1, s1-1)
+			assert.Truef(t, sna32EQ(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
+			assert.Truef(t, sna32EQ(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
+			assert.Falsef(t, sna32EQ(s1, s1+1), "s1 == s1+1 should be false: s1=0x%x s1+1=0x%x", s1, s1+1)
+			assert.Falsef(t, sna32EQ(s1, s1-1), "s1 == s1-1 hould be false: s1=0x%x s1-1=0x%x", s1, s1-1)
 
-			assert.True(t, sna32LTE(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
-			assert.True(t, sna32LTE(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
+			assert.Truef(t, sna32LTE(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
+			assert.Truef(t, sna32LTE(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
 
-			assert.True(t, sna32GTE(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
-			assert.True(t, sna32GTE(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
+			assert.Truef(t, sna32GTE(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
+			assert.Truef(t, sna32GTE(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
 		}
 	})
 
@@ -79,28 +79,28 @@ func TestSerialNumberArithmetic(t *testing.T) {
 			s2f := s1 + maxForwardDistance
 			s2b := s1 + maxBackwardDistance
 
-			assert.True(t, sna16LT(s1, s2f), "s1 < s2 should be true: s1=0x%x s2=0x%x", s1, s2f)
-			assert.False(t, sna16LT(s1, s2b), "s1 < s2 should be false: s1=0x%x s2=0x%x", s1, s2b)
+			assert.Truef(t, sna16LT(s1, s2f), "s1 < s2 should be true: s1=0x%x s2=0x%x", s1, s2f)
+			assert.Falsef(t, sna16LT(s1, s2b), "s1 < s2 should be false: s1=0x%x s2=0x%x", s1, s2b)
 
-			assert.False(t, sna16GT(s1, s2f), "s1 > s2 should be fales: s1=0x%x s2=0x%x", s1, s2f)
-			assert.True(t, sna16GT(s1, s2b), "s1 > s2 should be true: s1=0x%x s2=0x%x", s1, s2b)
+			assert.Falsef(t, sna16GT(s1, s2f), "s1 > s2 should be fales: s1=0x%x s2=0x%x", s1, s2f)
+			assert.Truef(t, sna16GT(s1, s2b), "s1 > s2 should be true: s1=0x%x s2=0x%x", s1, s2b)
 
-			assert.True(t, sna16LTE(s1, s2f), "s1 <= s2 should be true: s1=0x%x s2=0x%x", s1, s2f)
-			assert.False(t, sna16LTE(s1, s2b), "s1 <= s2 should be false: s1=0x%x s2=0x%x", s1, s2b)
+			assert.Truef(t, sna16LTE(s1, s2f), "s1 <= s2 should be true: s1=0x%x s2=0x%x", s1, s2f)
+			assert.Falsef(t, sna16LTE(s1, s2b), "s1 <= s2 should be false: s1=0x%x s2=0x%x", s1, s2b)
 
-			assert.False(t, sna16GTE(s1, s2f), "s1 >= s2 should be fales: s1=0x%x s2=0x%x", s1, s2f)
-			assert.True(t, sna16GTE(s1, s2b), "s1 >= s2 should be true: s1=0x%x s2=0x%x", s1, s2b)
+			assert.Falsef(t, sna16GTE(s1, s2f), "s1 >= s2 should be fales: s1=0x%x s2=0x%x", s1, s2f)
+			assert.Truef(t, sna16GTE(s1, s2b), "s1 >= s2 should be true: s1=0x%x s2=0x%x", s1, s2b)
 
-			assert.True(t, sna16EQ(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
-			assert.True(t, sna16EQ(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
-			assert.False(t, sna16EQ(s1, s1+1), "s1 == s1+1 should be false: s1=0x%x s1+1=0x%x", s1, s1+1)
-			assert.False(t, sna16EQ(s1, s1-1), "s1 == s1-1 hould be false: s1=0x%x s1-1=0x%x", s1, s1-1)
+			assert.Truef(t, sna16EQ(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
+			assert.Truef(t, sna16EQ(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
+			assert.Falsef(t, sna16EQ(s1, s1+1), "s1 == s1+1 should be false: s1=0x%x s1+1=0x%x", s1, s1+1)
+			assert.Falsef(t, sna16EQ(s1, s1-1), "s1 == s1-1 hould be false: s1=0x%x s1-1=0x%x", s1, s1-1)
 
-			assert.True(t, sna16LTE(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
-			assert.True(t, sna16LTE(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
+			assert.Truef(t, sna16LTE(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
+			assert.Truef(t, sna16LTE(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
 
-			assert.True(t, sna16GTE(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
-			assert.True(t, sna16GTE(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
+			assert.Truef(t, sna16GTE(s1, s1), "s1 == s1 should be true: s1=0x%x s2=0x%x", s1, s1)
+			assert.Truef(t, sna16GTE(s2b, s2b), "s2 == s2 should be true: s2=0x%x s2=0x%x", s2b, s2b)
 		}
 	})
 }

--- a/vnet_test.go
+++ b/vnet_test.go
@@ -272,7 +272,7 @@ func testRwndFull(t *testing.T, unordered bool) { //nolint:cyclop
 				return
 			}
 			log.Infof("server read %d bytes", n)
-			assert.True(t, reflect.DeepEqual(msg, buf[:n]), "msg %d should match", i)
+			assert.Truef(t, reflect.DeepEqual(msg, buf[:n]), "msg %d should match", i)
 		}
 
 		close(serverReadAll)


### PR DESCRIPTION
#### Description

Use testify/assert in place of the standard testing package, and update where applicable to use `assert.NoError`

pion/.goassets/pull/222

#### Reference issue

N/A
