### PR TITLE
Remove zero-checksum heuristic

### DIFF
--- a/association.go
+++ b/association.go
@@ -2766,12 +2766,6 @@ func (a *Association) onRetransmissionTimeout(id int, nRtos uint) { //nolint:cyc
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
-	// TSN hasn't been incremented in 3 attempts. Speculatively
-	// toggle ZeroChecksum because old Pion versions had a broken implementation
-	if a.cumulativeTSNAckPoint+1 == a.initialTSN && nRtos%3 == 0 {
-		a.sendZeroChecksum = !a.sendZeroChecksum
-	}
-
 	if id == timerT1Init {
 		err := a.sendInit()
 		if err != nil {


### PR DESCRIPTION
#### Description

Remove the legacy interop heuristic that toggled sendZeroChecksum after repeated RTOs with no TSN progress. Confirmed legacy interop is no longer needed and the flip ends up prolonging loss with newer version peers that don't have the bad zero checksum interpretation logic (where it would assume Zero Checksum Acceptable parameter meant it would receive zero checksum data).

#### Reference issue
https://github.com/pion/sctp/issues/391


Fixes #391 
