### PR TITLE
Fix a typo for RFC reference in paramtype

### DIFF
--- a/paramtype.go
+++ b/paramtype.go
@@ -29,7 +29,7 @@ const (
 	addIncStreamsReq       paramType = 18    // Add Incoming Streams Request Parameter	[RFC6525]
 	ecnCapable             paramType = 32768 // ECN Capable (0x8000)	[RFC2960]
 	zeroChecksumAcceptable paramType = 32769 // Zero Checksum Acceptable [draft-ietf-tsvwg-sctp-zero-checksum-00]
-	random                 paramType = 32770 // Random (0x8002)	[RFC4805]
+	random                 paramType = 32770 // Random (0x8002)	[RFC4895]
 	chunkList              paramType = 32771 // Chunk List (0x8003)	[RFC4895]
 	reqHMACAlgo            paramType = 32772 // Requested HMAC Algorithm Parameter (0x8004)	[RFC4895]
 	padding                paramType = 32773 // Padding (0x8005)


### PR DESCRIPTION
#### Description
Fixes a tiny typo in a comment for the RFC reference. I found this when compiling what RFCs were being used in a PR that I will open up soon.

#### Reference issue
N/A
