### PR TITLE
Update param-forward-tsn-supported to RFC 9260

### DIFF
--- a/param_forward_tsn_supported.go
+++ b/param_forward_tsn_supported.go
@@ -3,9 +3,11 @@
 
 package sctp
 
+import "errors"
+
 // At the initialization of the association, the sender of the INIT or
 // INIT ACK chunk MAY include this OPTIONAL parameter to inform its peer
-// that it is able to support the Forward TSN chunk
+// that it supports the Forward TSN chunk (RFC 9260).
 //
 //   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -15,6 +17,11 @@ package sctp
 type paramForwardTSNSupported struct {
 	paramHeader
 }
+
+// Errors for Forward TSN Supported parameter.
+var (
+	ErrForwardTSNSupportedParamInvalidLength = errors.New("forward tsn supported parameter invalid length")
+)
 
 func (f *paramForwardTSNSupported) marshal() ([]byte, error) {
 	f.typ = forwardTSNSupp
@@ -27,6 +34,11 @@ func (f *paramForwardTSNSupported) unmarshal(raw []byte) (param, error) {
 	err := f.paramHeader.unmarshal(raw)
 	if err != nil {
 		return nil, err
+	}
+
+	// Must have no value (header-only parameter).
+	if len(f.raw) != 0 {
+		return nil, ErrForwardTSNSupportedParamInvalidLength
 	}
 
 	return f, nil


### PR DESCRIPTION
#### Description
- Adds a reference to RFC 9260 since it previously didn't refer to anything
- Adds a guard for if `raw` is empty in `unmarshal()`.
- Adds tests for the guard

#### Reference issue
Resolves #422.
