### PR TITLE
Update error_cause to RFC 9260

### DIFF
--- a/error_cause_header_test.go
+++ b/error_cause_header_test.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package sctp
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorCauseHeader_Marshal_Success(t *testing.T) {
+	header := &errorCauseHeader{
+		code: protocolViolation,
+		raw:  []byte("oops"),
+	}
+
+	b, err := header.marshal()
+	assert.NoError(t, err)
+
+	// length should be header(4) + len(raw)
+	wantLen := uint16(4 + len(header.raw)) // nolint:gosec
+	assert.Equal(t, wantLen, header.len)
+	assert.Equal(t, int(wantLen), len(b))
+
+	// header fields
+	gotCode := binary.BigEndian.Uint16(b)
+	gotLen := binary.BigEndian.Uint16(b[2:])
+	assert.Equal(t, uint16(protocolViolation), gotCode)
+	assert.Equal(t, wantLen, gotLen)
+
+	// value
+	assert.Equal(t, header.raw, b[4:])
+}
+
+func TestErrorCauseHeader_Marshal_TooLargeValue(t *testing.T) {
+	// one byte larger than the max allowed value length
+	tooBig := make([]byte, maxErrorCauseValueLen+1)
+
+	h := &errorCauseHeader{
+		code: invalidMandatoryParameter,
+		raw:  tooBig,
+	}
+
+	_, err := h.marshal()
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrCauseLengthInvalid)
+}
+
+func TestErrorCauseHeader_Unmarshal_Success(t *testing.T) {
+	// build a well-formed cause header by hand
+	value := []byte{0xde, 0xad, 0xbe, 0xef}
+	totalLen := uint16(4 + len(value)) // nolint:gosec
+
+	raw := make([]byte, totalLen)
+	binary.BigEndian.PutUint16(raw, uint16(userInitiatedAbort))
+	binary.BigEndian.PutUint16(raw[2:], totalLen)
+	copy(raw[4:], value)
+
+	var h errorCauseHeader
+	err := h.unmarshal(raw)
+	assert.NoError(t, err)
+	assert.Equal(t, userInitiatedAbort, h.code)
+	assert.Equal(t, totalLen, h.len)
+	assert.Equal(t, value, h.raw)
+}
+
+func TestErrorCauseHeader_Unmarshal_ShortInput(t *testing.T) {
+	var h errorCauseHeader
+	err := h.unmarshal([]byte{0x00, 0x01, 0x00}) // len < 4
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidSCTPChunk)
+}
+
+func TestErrorCauseHeader_Unmarshal_BadLength_SmallerThanHeader(t *testing.T) {
+	// declared length=3 (<4) but buffer has at least 4
+	raw := make([]byte, 4)
+	binary.BigEndian.PutUint16(raw, uint16(invalidMandatoryParameter))
+	binary.BigEndian.PutUint16(raw[2:], 3)
+
+	var h errorCauseHeader
+	err := h.unmarshal(raw)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidSCTPChunk)
+}
+
+func TestErrorCauseHeader_Unmarshal_BadLength_ClaimsMoreThanSlice(t *testing.T) {
+	// declared length=10 but actual slice len=8
+	raw := make([]byte, 8)
+	binary.BigEndian.PutUint16(raw, uint16(unrecognizedChunkType))
+	binary.BigEndian.PutUint16(raw[2:], 10)
+
+	var h errorCauseHeader
+	err := h.unmarshal(raw)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidSCTPChunk)
+}
+
+func TestErrorCauseHeader_RoundTrip(t *testing.T) {
+	orig := &errorCauseHeader{
+		code: unresolvableAddress,
+		raw:  []byte("addr-bad"),
+	}
+
+	b, err := orig.marshal()
+	assert.NoError(t, err)
+
+	var got errorCauseHeader
+	err = got.unmarshal(b)
+	assert.NoError(t, err)
+
+	assert.Equal(t, orig.code, got.code)
+	assert.Equal(t, orig.len, got.len)
+	assert.Equal(t, orig.raw, got.raw)
+}
+
+func TestErrorCauseHeader_Unmarshal_IgnoresTrailingBytes(t *testing.T) {
+	// declared length=8 (header+value), but provide 12 bytes total (4 extra trailing bytes).
+	value := []byte{1, 2, 3, 4}
+	totalLen := uint16(4 + len(value)) // nolint:gosec
+	raw := make([]byte, 12)
+	binary.BigEndian.PutUint16(raw, uint16(noUserData))
+	binary.BigEndian.PutUint16(raw[2:], totalLen)
+	copy(raw[4:], value)
+	// trailing bytes (not considered padding here, header just selects the first 'len' bytes)
+	copy(raw[8:], []byte{9, 9, 9, 9})
+
+	var h errorCauseHeader
+	err := h.unmarshal(raw)
+	assert.NoError(t, err)
+	assert.Equal(t, noUserData, h.code)
+	assert.Equal(t, totalLen, h.len)
+	assert.Equal(t, value, h.raw) // should not include trailing bytes
+}
+
+func TestErrorCauseHeader_String(t *testing.T) {
+	h := errorCauseHeader{code: cookieReceivedWhileShuttingDown}
+	assert.Equal(t, "Cookie Received While Shutting Down", h.String())
+}

--- a/error_cause_protocol_violation.go
+++ b/error_cause_protocol_violation.go
@@ -12,9 +12,9 @@ import (
 This error cause MAY be included in ABORT chunks that are sent
 because an SCTP endpoint detects a protocol violation of the peer
 that is not covered by the error causes described in Section 3.3.10.1
-to Section 3.3.10.12.  An implementation MAY provide additional
+to Section 3.3.10.12. An implementation MAY provide additional
 information specifying what kind of protocol violation has been
-detected.
+detected. (RFC 9260)
 
 	 0                   1                   2                   3
 	 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -36,14 +36,14 @@ var (
 )
 
 func (e *errorCauseProtocolViolation) marshal() ([]byte, error) {
+	e.code = protocolViolation
 	e.raw = e.additionalInformation
 
 	return e.errorCauseHeader.marshal()
 }
 
 func (e *errorCauseProtocolViolation) unmarshal(raw []byte) error {
-	err := e.errorCauseHeader.unmarshal(raw)
-	if err != nil {
+	if err := e.errorCauseHeader.unmarshal(raw); err != nil {
 		return fmt.Errorf("%w: %v", ErrProtocolViolationUnmarshal, err) //nolint:errorlint
 	}
 

--- a/error_cause_test.go
+++ b/error_cause_test.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package sctp
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorCauseCode_String(t *testing.T) {
+	cases := []struct {
+		code     errorCauseCode
+		expected string
+	}{
+		{invalidStreamIdentifier, "Invalid Stream Identifier"},
+		{missingMandatoryParameter, "Missing Mandatory Parameter"},
+		{staleCookieError, "Stale Cookie Error"},
+		{outOfResource, "Out of Resource"},
+		{unresolvableAddress, "Unresolvable Address"},
+		{unrecognizedChunkType, "Unrecognized Chunk Type"},
+		{invalidMandatoryParameter, "Invalid Mandatory Parameter"},
+		{unrecognizedParameters, "Unrecognized Parameters"},
+		{noUserData, "No User Data"},
+		{cookieReceivedWhileShuttingDown, "Cookie Received While Shutting Down"},
+		{restartOfAnAssociationWithNewAddresses, "Restart of an Association with New Addresses"},
+		{userInitiatedAbort, "User Initiated Abort"},
+		{protocolViolation, "Protocol Violation"},
+		{errorCauseCode(0xFFFF), "Unknown CauseCode: 65535"},
+	}
+
+	for _, tc := range cases {
+		assert.Equalf(t, tc.expected, tc.code.String(), "stringer mismatch for code %d", tc.code)
+	}
+}
+
+func TestBuildErrorCause_TooShort(t *testing.T) {
+	_, err := buildErrorCause([]byte{0x00, 0x01, 0x00})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrCauseTooShort)
+}
+
+func TestBuildErrorCause_LengthInvalid_TooSmallField(t *testing.T) {
+	// Length field = 3 (<4) while slice has 4 bytes
+	raw := make([]byte, 4)
+	// code any
+	binary.BigEndian.PutUint16(raw, 0)
+	// length=3 -> invalid
+	binary.BigEndian.PutUint16(raw[2:], 3)
+
+	_, err := buildErrorCause(raw)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrCauseLengthInvalid)
+}
+
+func TestBuildErrorCause_LengthInvalid_ClaimsMoreThanSlice(t *testing.T) {
+	// length field = 8, but slice is only 6
+	raw := make([]byte, 6)
+	binary.BigEndian.PutUint16(raw, 0)
+	binary.BigEndian.PutUint16(raw[2:], 8)
+
+	_, err := buildErrorCause(raw)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrCauseLengthInvalid)
+}
+
+func TestBuildErrorCause_UnknownCode(t *testing.T) {
+	// valid 4-byte header, unknown code -> ErrBuildErrorCaseHandle
+	raw := make([]byte, 4)
+	binary.BigEndian.PutUint16(raw, uint16(0xFFFF))
+	binary.BigEndian.PutUint16(raw[2:], 4)
+
+	_, err := buildErrorCause(raw)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBuildErrorCaseHandle)
+}
+
+func TestBuildErrorCause_Dispatch_ProtocolViolation_RoundTrip(t *testing.T) {
+	orig := &errorCauseProtocolViolation{
+		errorCauseHeader:      errorCauseHeader{code: protocolViolation},
+		additionalInformation: []byte("violation: unexpected state"),
+	}
+	b, err := orig.marshal()
+	assert.NoError(t, err)
+
+	got, err := buildErrorCause(b)
+	assert.NoError(t, err)
+	assert.Equal(t, protocolViolation, got.errorCauseCode())
+
+	epv, ok := got.(*errorCauseProtocolViolation)
+	assert.True(t, ok, "built cause should be *errorCauseProtocolViolation")
+	assert.Equal(t, orig.additionalInformation, epv.additionalInformation)
+
+	b2, err := got.marshal()
+	assert.NoError(t, err)
+	assert.Equal(t, b, b2)
+}
+
+func TestBuildErrorCause_Dispatch_UserInitiatedAbort_RoundTrip(t *testing.T) {
+	orig := &errorCauseUserInitiatedAbort{
+		errorCauseHeader:      errorCauseHeader{code: userInitiatedAbort},
+		upperLayerAbortReason: []byte("app-requested abort"),
+	}
+	b, err := orig.marshal()
+	assert.NoError(t, err)
+
+	got, err := buildErrorCause(b)
+	assert.NoError(t, err)
+	assert.Equal(t, userInitiatedAbort, got.errorCauseCode())
+
+	euia, ok := got.(*errorCauseUserInitiatedAbort)
+	assert.True(t, ok, "built cause should be *errorCauseUserInitiatedAbort")
+	assert.Equal(t, orig.upperLayerAbortReason, euia.upperLayerAbortReason)
+
+	// Round-trip again
+	b2, err := got.marshal()
+	assert.NoError(t, err)
+	assert.Equal(t, b, b2)
+}

--- a/error_cause_unrecognized_chunk_type.go
+++ b/error_cause_unrecognized_chunk_type.go
@@ -17,8 +17,7 @@ func (e *errorCauseUnrecognizedChunkType) marshal() ([]byte, error) {
 }
 
 func (e *errorCauseUnrecognizedChunkType) unmarshal(raw []byte) error {
-	err := e.errorCauseHeader.unmarshal(raw)
-	if err != nil {
+	if err := e.errorCauseHeader.unmarshal(raw); err != nil {
 		return err
 	}
 

--- a/error_cause_user_initiated_abort.go
+++ b/error_cause_user_initiated_abort.go
@@ -9,9 +9,9 @@ import (
 
 /*
 This error cause MAY be included in ABORT chunks that are sent
-because of an upper-layer request.  The upper layer can specify an
+because of an upper-layer request. The upper layer can specify an
 Upper Layer Abort Reason that is transported by SCTP transparently
-and MAY be delivered to the upper-layer protocol at the peer.
+and MAY be delivered to the upper-layer protocol at the peer. (RFC 9260)
 
 	 0                   1                   2                   3
 	 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -35,8 +35,7 @@ func (e *errorCauseUserInitiatedAbort) marshal() ([]byte, error) {
 }
 
 func (e *errorCauseUserInitiatedAbort) unmarshal(raw []byte) error {
-	err := e.errorCauseHeader.unmarshal(raw)
-	if err != nil {
+	if err := e.errorCauseHeader.unmarshal(raw); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### Description
- Updated `error_cause.go` to have updated errors according to RFC 9260
- Added an error for other causes if the length is too short
- Added references to RFC 9260 where applicable

#### Reference issue
Resolves #424.
