### PR TITLE
Update remaining chunk files to RFC 9260

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -3262,11 +3262,13 @@ func TestAssociation_HandlePacketInCookieWaitState(t *testing.T) {
 			// Prevent "use of close network connection" error on close.
 			skipClose: true,
 		},
-		"CoockeEcho": {
+		"CookieEcho": {
 			inputPacket: &packet{
 				sourcePort:      1,
 				destinationPort: 1,
-				chunks:          []chunk{&chunkCookieEcho{}},
+				chunks: []chunk{&chunkCookieEcho{
+					cookie: []byte{0x01},
+				}},
 			},
 		},
 		"HeartBeat": {
@@ -3280,7 +3282,11 @@ func TestAssociation_HandlePacketInCookieWaitState(t *testing.T) {
 			inputPacket: &packet{
 				sourcePort:      1,
 				destinationPort: 1,
-				chunks:          []chunk{&chunkPayloadData{}},
+				chunks: []chunk{&chunkPayloadData{
+					beginningFragment: true,         // B = 1
+					endingFragment:    true,         // E = 1
+					userData:          []byte{0x00}, // L > 0
+				}},
 			},
 		},
 		"Sack": {

--- a/chunk_cookie_ack.go
+++ b/chunk_cookie_ack.go
@@ -11,10 +11,10 @@ import (
 /*
 chunkCookieAck represents an SCTP Chunk of type chunkCookieAck
 
-	 0                   1                   2                   3
-	 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	0                   1                   2                   3
+	0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	|   Type = 11   |Chunk  Flags   |     Length = 4                |
+	|   Type = 11   |  Chunk Flags  |     Length = 4                |
 	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 */
 type chunkCookieAck struct {
@@ -24,6 +24,7 @@ type chunkCookieAck struct {
 // Cookie ack chunk errors.
 var (
 	ErrChunkTypeNotCookieAck = errors.New("ChunkType is not of type COOKIEACK")
+	ErrCookieAckHasValue     = errors.New("COOKIE ACK must not contain a value")
 )
 
 func (c *chunkCookieAck) unmarshal(raw []byte) error {
@@ -35,11 +36,19 @@ func (c *chunkCookieAck) unmarshal(raw []byte) error {
 		return fmt.Errorf("%w: actually is %s", ErrChunkTypeNotCookieAck, c.typ.String())
 	}
 
+	// flags are reserved: sender sets 0, receiver ignores.
+	// COOKIE ACK has no body: value length must be 0.
+	if len(c.raw) != 0 {
+		return ErrCookieAckHasValue
+	}
+
 	return nil
 }
 
 func (c *chunkCookieAck) marshal() ([]byte, error) {
 	c.chunkHeader.typ = ctCookieAck
+	c.chunkHeader.flags = 0 // sender MUST set to 0
+	c.chunkHeader.raw = nil // no body
 
 	return c.chunkHeader.marshal()
 }

--- a/chunk_heartbeat.go
+++ b/chunk_heartbeat.go
@@ -9,32 +9,16 @@ import (
 )
 
 /*
-chunkHeartbeat represents an SCTP Chunk of type HEARTBEAT
+chunkHeartbeat represents an SCTP Chunk of type HEARTBEAT (RFC 9260 section 3.3.6)
 
-An endpoint should send this chunk to its peer endpoint to probe the
-reachability of a particular destination transport address defined in
-the present association.
+An endpoint sends this chunk to probe reachability of a destination address.
+The chunk MUST contain exactly one variable-length parameter:
 
-The parameter field contains the Heartbeat Information, which is a
-variable-length opaque data structure understood only by the sender.
-
-	 0                   1                   2                   3
-	 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	|   Type = 4    | Chunk  Flags  |      Heartbeat Length         |
-	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	|                                                               |
-	|            Heartbeat Information TLV (Variable-Length)        |
-	|                                                               |
-	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-Defined as a variable-length parameter using the format described
-in Section 3.2.1, i.e.:
-
-Variable Parameters                  Status     Type Value
+Variable Parameters                 Status     Type Value
 -------------------------------------------------------------
-heartbeat Info                       Mandatory   1
-.
+Heartbeat Info                      Mandatory  1
+
+nolint:godot
 */
 type chunkHeartbeat struct {
 	chunkHeader
@@ -48,20 +32,26 @@ var (
 	ErrParseParamTypeFailed       = errors.New("failed to parse param type")
 	ErrHeartbeatParam             = errors.New("heartbeat should only have HEARTBEAT param")
 	ErrHeartbeatChunkUnmarshal    = errors.New("failed unmarshalling param in Heartbeat Chunk")
+	ErrHeartbeatExtraNonZero      = errors.New("heartbeat has non-zero trailing bytes after last parameter")
+	ErrHeartbeatMarshalNoInfo     = errors.New("heartbeat marshal requires exactly one Heartbeat Info parameter")
 )
 
-func (h *chunkHeartbeat) unmarshal(raw []byte) error {
+func (h *chunkHeartbeat) unmarshal(raw []byte) error { //nolint:cyclop
 	if err := h.chunkHeader.unmarshal(raw); err != nil {
 		return err
-	} else if h.typ != ctHeartbeat {
+	}
+
+	if h.typ != ctHeartbeat {
 		return fmt.Errorf("%w: actually is %s", ErrChunkTypeNotHeartbeat, h.typ.String())
 	}
 
-	if len(raw) <= chunkHeaderSize {
-		return fmt.Errorf("%w: %d", ErrHeartbeatNotLongEnoughInfo, len(raw))
+	// flags: sender sets to 0, receiver ignores (RFC 9260).
+	// need at least a parameter header present (TLV: 4 bytes minimum).
+	if len(h.raw) < initOptionalVarHeaderLength {
+		return fmt.Errorf("%w: %d", ErrHeartbeatNotLongEnoughInfo, len(h.raw))
 	}
 
-	pType, err := parseParamType(raw[chunkHeaderSize:])
+	pType, err := parseParamType(h.raw)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrParseParamTypeFailed, err) //nolint:errorlint
 	}
@@ -69,17 +59,54 @@ func (h *chunkHeartbeat) unmarshal(raw []byte) error {
 		return fmt.Errorf("%w: instead have %s", ErrHeartbeatParam, pType.String())
 	}
 
-	p, err := buildParam(pType, raw[chunkHeaderSize:])
+	// then read the full TLV header to obtain the length for bounds checking.
+	var pHeader paramHeader
+	if e := pHeader.unmarshal(h.raw); e != nil {
+		return fmt.Errorf("%w: %v", ErrParseParamTypeFailed, e) //nolint:errorlint
+	}
+
+	plen := pHeader.length()
+	if plen < initOptionalVarHeaderLength || plen > len(h.raw) {
+		return ErrHeartbeatNotLongEnoughInfo
+	}
+
+	// build the single Heartbeat Info parameter from the exact TLV slice.
+	p, err := buildParam(pType, h.raw[:plen])
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrHeartbeatChunkUnmarshal, err) //nolint:errorlint
 	}
 	h.params = append(h.params, p)
 
+	// any trailing bytes beyond the single param must be all zeros.
+	if rem := h.raw[plen:]; len(rem) > 0 && !allZero(rem) {
+		return ErrHeartbeatExtraNonZero
+	}
+
 	return nil
 }
 
 func (h *chunkHeartbeat) Marshal() ([]byte, error) {
-	return nil, ErrUnimplemented
+	// exactly one Heartbeat Info param is required.
+	if len(h.params) != 1 {
+		return nil, ErrHeartbeatMarshalNoInfo
+	}
+
+	// enforce correct concrete type via type assertion (param interface has no type getter).
+	if _, ok := h.params[0].(*paramHeartbeatInfo); !ok {
+		return nil, ErrHeartbeatParam
+	}
+
+	pp, err := h.params[0].marshal()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrHeartbeatChunkUnmarshal, err) //nolint:errorlint
+	}
+
+	// single TLV, no inter-parameter padding within the chunk body.
+	h.chunkHeader.typ = ctHeartbeat
+	h.chunkHeader.flags = 0 // sender MUST set to 0
+	h.chunkHeader.raw = append([]byte(nil), pp...)
+
+	return h.chunkHeader.marshal()
 }
 
 func (h *chunkHeartbeat) check() (abort bool, err error) {

--- a/chunk_init.go
+++ b/chunk_init.go
@@ -9,7 +9,7 @@ import (
 )
 
 /*
-Init represents an SCTP Chunk of type INIT
+Init represents an SCTP Chunk of type INIT (RFC 9260 §3.3.2)
 
 See chunkInitCommon for the fixed headers
 
@@ -52,12 +52,9 @@ func (i *chunkInit) unmarshal(raw []byte) error {
 		return fmt.Errorf("%w: %d actual: %d", ErrChunkValueNotLongEnough, initChunkMinLength, len(i.raw))
 	}
 
-	// The Chunk Flags field in INIT is reserved, and all bits in it should
-	// be set to 0 by the sender and ignored by the receiver.  The sequence
-	// of parameters within an INIT can be processed in any order.
-	if i.flags != 0 {
-		return ErrChunkTypeInitFlagZero
-	}
+	// RFC 9260: INIT Chunk Flags are reserved; set to 0 by sender and
+	// ignored by receiver. Do NOT fail if non-zero. (We still set them
+	// to 0 on marshal.)
 
 	if err := i.chunkInitCommon.unmarshal(i.raw); err != nil {
 		return fmt.Errorf("%w: %v", ErrChunkTypeInitUnmarshalFailed, err) //nolint:errorlint
@@ -73,60 +70,34 @@ func (i *chunkInit) marshal() ([]byte, error) {
 	}
 
 	i.chunkHeader.typ = ctInit
+	i.chunkHeader.flags = 0 // RFC 9260: sender MUST set INIT flags to 0
 	i.chunkHeader.raw = initShared
 
 	return i.chunkHeader.marshal()
 }
 
 func (i *chunkInit) check() (abort bool, err error) {
-	// The receiver of the INIT (the responding end) records the value of
-	// the Initiate Tag parameter.  This value MUST be placed into the
-	// Verification Tag field of every SCTP packet that the receiver of
-	// the INIT transmits within this association.
-	//
-	// The Initiate Tag is allowed to have any value except 0.  See
-	// Section 5.3.1 for more on the selection of the tag value.
-	//
-	// If the value of the Initiate Tag in a received INIT chunk is found
-	// to be 0, the receiver MUST treat it as an error and close the
-	// association by transmitting an ABORT.
+	// Initiate Tag MUST NOT be 0.
 	if i.initiateTag == 0 {
 		return true, ErrChunkTypeInitInitateTagZero
 	}
 
-	// Defines the maximum number of streams the sender of this INIT
-	// chunk allows the peer end to create in this association.  The
-	// value 0 MUST NOT be used.
-	//
-	// Note: There is no negotiation of the actual number of streams but
-	// instead the two endpoints will use the min(requested, offered).
-	// See Section 5.1.1 for details.
-	//
-	// Note: A receiver of an INIT with the MIS value of 0 SHOULD abort
-	// the association.
+	// MIS (inbound streams requested) MUST NOT be 0.
 	if i.numInboundStreams == 0 {
 		return true, ErrInitInboundStreamRequestZero
 	}
 
-	// Defines the number of outbound streams the sender of this INIT
-	// chunk wishes to create in this association.  The value of 0 MUST
-	// NOT be used.
-	//
-	// Note: A receiver of an INIT with the OS value set to 0 SHOULD
-	// abort the association.
-
+	// OS (outbound streams requested) MUST NOT be 0.
 	if i.numOutboundStreams == 0 {
 		return true, ErrInitOutboundStreamRequestZero
 	}
 
-	// An SCTP receiver MUST be able to receive a minimum of 1500 bytes in
-	// one SCTP packet.  This means that an SCTP endpoint MUST NOT indicate
-	// less than 1500 bytes in its initial a_rwnd sent in the INIT or INIT
-	// ACK.
+	// a_rwnd MUST be >= 1500 bytes in INIT/INIT-ACK.
 	if i.advertisedReceiverWindowCredit < 1500 {
 		return true, ErrInitAdvertisedReceiver1500
 	}
 
+	// Unknown parameter handling per Parameter Header semantics.
 	for _, p := range i.unrecognizedParams {
 		if p.unrecognizedAction == paramHeaderUnrecognizedActionStop ||
 			p.unrecognizedAction == paramHeaderUnrecognizedActionStopAndReport {


### PR DESCRIPTION
#### Description
Update the remaining chunk files to RFC 9260 with the exception of chunk-reconfig which follows RFC 6525 and requires more updates in association.go.

Requires #427 to be merged first.

#### Reference issue
Resolves #426.
