### PR TITLE
Add post handshake metadata

### DIFF
--- a/association.go
+++ b/association.go
@@ -78,6 +78,31 @@ const (
 	defaultMaxMessageSize uint32 = 65536
 )
 
+// PartialReliabilityMode indicates the negotiated partial reliability mode.
+type PartialReliabilityMode int
+
+// PartialReliabilityMode values.
+const (
+	PartialReliabilityModeNone PartialReliabilityMode = iota
+	PartialReliabilityModeForwardTSN
+	PartialReliabilityModeIForwardTSN
+)
+
+// AssociationMetadata describes negotiated association capabilities.
+type AssociationMetadata struct {
+	// MessageInterleavingEnabled indicates whether RFC 8260 user message interleaving was negotiated.
+	MessageInterleavingEnabled bool `json:"messageInterleavingEnabled"`
+
+	// PartialReliabilityMode indicates which FORWARD-TSN variant is active.
+	PartialReliabilityMode PartialReliabilityMode `json:"partialReliabilityMode"`
+
+	// ZeroChecksumSendingEnabled indicates whether outgoing packets use zero checksum.
+	ZeroChecksumSendingEnabled bool `json:"zeroChecksumSendingEnabled"`
+
+	// ZeroChecksumReceivingEnabled indicates whether incoming packets may use zero checksum.
+	ZeroChecksumReceivingEnabled bool `json:"zeroChecksumReceivingEnabled"`
+}
+
 // association state enums.
 const (
 	closed uint32 = iota
@@ -1757,6 +1782,32 @@ func (a *Association) setRWND(rwnd uint32) {
 // SRTT returns the latest smoothed round-trip time (srrt).
 func (a *Association) SRTT() float64 {
 	return a.srtt.Load().(float64) //nolint:forcetypeassert
+}
+
+// Metadata returns negotiated association metadata. The ok return value is false
+// until the SCTP handshake has completed.
+func (a *Association) Metadata() (AssociationMetadata, bool) {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+
+	if a.getState() != established {
+		return AssociationMetadata{}, false
+	}
+
+	partialReliabilityMode := PartialReliabilityModeNone
+	switch {
+	case a.useIForwardTSN:
+		partialReliabilityMode = PartialReliabilityModeIForwardTSN
+	case a.useForwardTSN:
+		partialReliabilityMode = PartialReliabilityModeForwardTSN
+	}
+
+	return AssociationMetadata{
+		MessageInterleavingEnabled:   a.useInterleaving,
+		PartialReliabilityMode:       partialReliabilityMode,
+		ZeroChecksumSendingEnabled:   a.sendZeroChecksum,
+		ZeroChecksumReceivingEnabled: a.recvZeroChecksum,
+	}, true
 }
 
 // getMaxTSNOffset returns the maximum offset over the current cummulative TSN that

--- a/association_test.go
+++ b/association_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	cryptoRand "crypto/rand"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -810,6 +811,21 @@ func TestAssociationInterleavingNegotiationPayloadChunkType(t *testing.T) {
 			require.Equal(t, tt.useInterleaving, a0.useInterleaving)
 			require.Equal(t, tt.useInterleaving, a1.useInterleaving)
 
+			metadata0, ok := a0.Metadata()
+			require.True(t, ok)
+			require.Equal(t, tt.useInterleaving, metadata0.MessageInterleavingEnabled)
+			require.False(t, metadata0.ZeroChecksumSendingEnabled)
+			require.False(t, metadata0.ZeroChecksumReceivingEnabled)
+			if tt.useInterleaving {
+				require.Equal(t, PartialReliabilityModeIForwardTSN, metadata0.PartialReliabilityMode)
+			} else {
+				require.Equal(t, PartialReliabilityModeForwardTSN, metadata0.PartialReliabilityMode)
+			}
+
+			metadata1, ok := a1.Metadata()
+			require.True(t, ok)
+			require.Equal(t, metadata0, metadata1)
+
 			s0, s1, err := establishSessionPair(br, a0, a1, si)
 			require.NoError(t, err, "failed to establish session pair")
 
@@ -829,6 +845,34 @@ func TestAssociationInterleavingNegotiationPayloadChunkType(t *testing.T) {
 			require.Equal(t, msg, string(buf[:n]))
 		})
 	}
+}
+
+func TestAssociationMetadataNotReadyBeforeHandshake(t *testing.T) {
+	assoc := createTestAssociation(t, Config{
+		NetConn: &dumbConn{},
+	})
+
+	metadata, ok := assoc.Metadata()
+	require.False(t, ok)
+	require.Equal(t, AssociationMetadata{}, metadata)
+}
+
+func TestAssociationMetadataJSON(t *testing.T) {
+	metadata := AssociationMetadata{
+		MessageInterleavingEnabled:   true,
+		PartialReliabilityMode:       PartialReliabilityModeIForwardTSN,
+		ZeroChecksumSendingEnabled:   true,
+		ZeroChecksumReceivingEnabled: true,
+	}
+
+	raw, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"messageInterleavingEnabled": true,
+		"partialReliabilityMode": 2,
+		"zeroChecksumSendingEnabled": true,
+		"zeroChecksumReceivingEnabled": true
+	}`, string(raw))
 }
 
 func TestAssociationInterleavingProtocolViolationWrongPayloadChunkType(t *testing.T) {


### PR DESCRIPTION
#### Description
Add struct so users of the library can infer if interleaving, zero-checksum and other stuff in the future, are enabled or not, this can be extended for https://github.com/pion/sctp/pull/463 

based on https://github.com/pion/sctp/pull/443