### PR TITLE
Accept unrecognized error cause codes in ABORT

### DIFF
--- a/chunk_abort_test.go
+++ b/chunk_abort_test.go
@@ -57,4 +57,45 @@ func TestAbortChunk(t *testing.T) {
 				"errorCause code should match")
 		}
 	})
+
+	t.Run("Unrecognized error cause code is accepted as opaque TLV", func(t *testing.T) {
+		const unknownCode errorCauseCode = 0xFFFF
+
+		// Build a raw ABORT with one unrecognized 4-byte cause (code=0xFFFF, len=4, no value).
+		// chunkHeader: type(1) flags(1) length(2) = 4 bytes; cause TLV: 4 bytes → total 8.
+		raw := []byte{
+			byte(ctAbort), 0x00, 0x00, 0x08, // chunk header: type, flags, length=8
+			0xFF, 0xFF, 0x00, 0x04, // cause: code=0xFFFF, length=4 (header only)
+		}
+
+		abort := &chunkAbort{}
+		err := abort.unmarshal(raw)
+		assert.NoError(t, err, "ABORT with unrecognized cause code should not fail")
+		assert.Equal(t, 1, len(abort.errorCauses), "should have one error cause")
+		assert.Equal(t, unknownCode, abort.errorCauses[0].errorCauseCode(), "cause code should be preserved")
+	})
+
+	t.Run("Unrecognized error cause code mixed with known causes", func(t *testing.T) {
+		const unknownCode errorCauseCode = 0x00FF
+
+		// ABORT containing: unknown cause first, followed by a known cause (protocolViolation=13).
+		abort1 := &chunkAbort{
+			errorCauses: []errorCause{
+				// Unknown cause represented as an opaque errorCauseHeader.
+				&errorCauseHeader{code: unknownCode},
+				&errorCauseProtocolViolation{
+					errorCauseHeader: errorCauseHeader{code: protocolViolation},
+				},
+			},
+		}
+		bytes, err := abort1.marshal()
+		assert.NoError(t, err, "marshal should succeed")
+
+		abort2 := &chunkAbort{}
+		err = abort2.unmarshal(bytes)
+		assert.NoError(t, err, "unmarshal with unknown cause code should not fail")
+		assert.Equal(t, 2, len(abort2.errorCauses), "should have two error causes")
+		assert.Equal(t, unknownCode, abort2.errorCauses[0].errorCauseCode(), "unknown cause code should be preserved")
+		assert.Equal(t, protocolViolation, abort2.errorCauses[1].errorCauseCode(), "second cause code should match")
+	})
 }

--- a/error_cause.go
+++ b/error_cause.go
@@ -41,7 +41,13 @@ func buildErrorCause(raw []byte) (errorCause, error) {
 	case userInitiatedAbort:
 		errCause = &errorCauseUserInitiatedAbort{}
 	default:
-		return nil, fmt.Errorf("%w: %s", ErrBuildErrorCaseHandle, c.String())
+		// Unknown cause — treat as opaque TLV per RFC 9260 §3.2.1
+		e := &errorCauseHeader{}
+		if err := e.unmarshal(raw); err != nil {
+			return nil, err
+		}
+
+		return e, nil
 	}
 
 	if err := errCause.unmarshal(raw); err != nil {


### PR DESCRIPTION
## Summary

ABORT chunks containing unrecognized error cause codes were silently dropped
instead of being processed. This fix makes `buildErrorCause` treat any
unrecognized cause code as an opaque TLV and continue parsing, matching the
behavior required by RFC 9260 §3.2.1.

## Problem

`buildErrorCause` in `error_cause.go` handled only four known error cause codes
(`invalidMandatoryParameter`, `unrecognizedChunkType`, `protocolViolation`,
`userInitiatedAbort`). Any other code caused the function to return an error,
which propagated up through `chunkAbort.unmarshal` → `packet.unmarshal` →
`handleInbound`, where the entire packet was silently discarded.

As a result:

- A peer sending an ABORT that included any vendor-specific, experimental, or
  future-extension error cause code would find its ABORT ignored by the local
  endpoint, leaving the association open when it should be closed.
- A malicious connected peer could deliberately prepend an unrecognized 4-byte
  cause TLV to an ABORT to prevent the local endpoint from ever processing the
  termination signal, accumulating stale associations and exhausting server
  resources.
