### PR TITLE
Set cap of ReassemblyQueue based on rwnd size

### DIFF
--- a/association.go
+++ b/association.go
@@ -2444,7 +2444,7 @@ func (a *Association) createStream(streamIdentifier uint16, accept bool) *Stream
 	stream := &Stream{
 		association:      a,
 		streamIdentifier: streamIdentifier,
-		reassemblyQueue:  newReassemblyQueue(streamIdentifier),
+		reassemblyQueue:  newReassemblyQueue(streamIdentifier, a.maxReceiveBufferSize),
 		log:              a.log,
 		name:             fmt.Sprintf("%d:%s", streamIdentifier, a.name),
 		writeDeadline:    deadline.New(),

--- a/association_test.go
+++ b/association_test.go
@@ -1122,12 +1122,14 @@ func TestAssociationIForwardTSNDuplicateEntriesUseLargestMID(t *testing.T) {
 }
 
 func TestAssociationInterleavingProtocolViolationMIDLimit(t *testing.T) {
-	assoc := createTestAssociation(t, Config{})
+	const limit = maxReassemblyQueueMIDEntries
+	// receive buffer sized so the derived MID cap is exactly limit
+	assoc := createTestAssociation(t, Config{MaxReceiveBufferSize: reassemblyMIDLimitBytesPerEntry * limit})
 	assoc.useInterleaving = true
 	assoc.payloadQueue.init(0)
 	assoc.setState(established)
 
-	for i := range maxReassemblyQueueMIDEntries {
+	for i := range limit {
 		packets := assoc.handleData(&chunkPayloadData{
 			iData:                  true,
 			messageIdentifier:      uint32(i), //nolint:gosec // bounded by maxReassemblyQueueMIDEntries
@@ -1143,10 +1145,10 @@ func TestAssociationInterleavingProtocolViolationMIDLimit(t *testing.T) {
 
 	packets := assoc.handleData(&chunkPayloadData{
 		iData:                  true,
-		messageIdentifier:      maxReassemblyQueueMIDEntries,
+		messageIdentifier:      limit,
 		fragmentSequenceNumber: 0,
 		beginningFragment:      true,
-		tsn:                    maxReassemblyQueueMIDEntries + 1,
+		tsn:                    limit + 1,
 		streamIdentifier:       1,
 		payloadType:            PayloadTypeWebRTCBinary,
 	})

--- a/reassembly_queue.go
+++ b/reassembly_queue.go
@@ -197,15 +197,29 @@ type reassemblyQueue struct {
 	unorderedMIDMap map[uint32]*chunkSetMID
 	useInterleaving bool
 	nBytes          uint64
+	maxMIDEntries   int
 }
 
-var errTryAgain = errors.New("try again")
+var (
+	errTryAgain = errors.New("try again")
 
-const maxReassemblyQueueMIDEntries = 1024
+	errReassemblyQueueMIDLimitExceeded = errors.New("reassembly queue i-data message identifier limit exceeded")
+)
 
-var errReassemblyQueueMIDLimitExceeded = errors.New("reassembly queue i-data message identifier limit exceeded")
+const (
+	// reassemblyMIDLimitBytesPerEntry is the receive-buffer budget allotted per
+	// undelivered interleaved (i-data) message. The MID-entry cap is
+	// maxReceiveBufferSize/reassemblyMIDLimitBytesPerEntry, so reassembly memory
+	// scales with the configured buffer. the cap only bites pathological floods of tiny or
+	// header-only messages that a_rwnd cannot bound.
+	reassemblyMIDLimitBytesPerEntry = 64
 
-func newReassemblyQueue(si uint16) *reassemblyQueue {
+	maxReassemblyQueueMIDEntries = 1024
+)
+
+func newReassemblyQueue(si uint16, maxReceiveBufferSize uint32) *reassemblyQueue {
+	maxMIDEntries := max(int(maxReceiveBufferSize/reassemblyMIDLimitBytesPerEntry), maxReassemblyQueueMIDEntries)
+
 	// From RFC 4960 Sec 6.5:
 	//   The Stream Sequence Number in all the streams MUST start from 0 when
 	//   the association is established.  Also, when the Stream Sequence
@@ -221,6 +235,7 @@ func newReassemblyQueue(si uint16) *reassemblyQueue {
 		unorderedMID:    make([]*chunkSetMID, 0),
 		orderedMIDMap:   map[uint32]*chunkSetMID{},
 		unorderedMIDMap: map[uint32]*chunkSetMID{},
+		maxMIDEntries:   maxMIDEntries,
 	}
 }
 
@@ -324,7 +339,7 @@ func (r *reassemblyQueue) pushUnorderedIData(chunk *chunkPayloadData) (bool, err
 	}
 	cset := r.unorderedMIDMap[chunk.messageIdentifier]
 	if cset == nil {
-		if r.unorderedMIDEntryCount() >= maxReassemblyQueueMIDEntries {
+		if r.unorderedMIDEntryCount() >= r.maxMIDEntries {
 			return false, errReassemblyQueueMIDLimitExceeded
 		}
 		cset = newChunkSetMID(chunk.messageIdentifier, chunk.payloadType)
@@ -357,7 +372,7 @@ func (r *reassemblyQueue) pushOrderedIData(chunk *chunkPayloadData) (bool, error
 	}
 	cset := r.orderedMIDMap[chunk.messageIdentifier]
 	if cset == nil {
-		if len(r.orderedMIDMap) >= maxReassemblyQueueMIDEntries {
+		if len(r.orderedMIDMap) >= r.maxMIDEntries {
 			return false, errReassemblyQueueMIDLimitExceeded
 		}
 		cset = newChunkSetMID(chunk.messageIdentifier, chunk.payloadType)

--- a/reassembly_queue_test.go
+++ b/reassembly_queue_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	t.Run("ordered fragments", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -54,7 +54,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered fragments", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -110,7 +110,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered and unordered in the mix", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -168,7 +168,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("unordered complete skips incomplete", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -231,7 +231,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ignores chunk with wrong SI", func(t *testing.T) {
-		rq := newReassemblyQueue(123)
+		rq := newReassemblyQueue(123, initialRecvBufSize)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -254,7 +254,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ignores chunk with stale SSN", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 		rq.nextSSN = 7 // forcibly set expected SSN to 7
 
 		orgPpi := PayloadTypeWebRTCBinary
@@ -277,7 +277,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("should fail to read incomplete chunk", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -303,7 +303,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("should fail to read if the next SSN is not ready", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -330,7 +330,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("detect buffer too short", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		for _, chunk := range []*chunkPayloadData{
@@ -374,7 +374,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("forwardTSN for ordered fragments", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -426,7 +426,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("forwardTSN for unordered fragments", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -483,7 +483,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("fragmented and unfragmented chunks with the same ssn", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -521,7 +521,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("i-data ordered fragments by fsn", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		chunk1 := &chunkPayloadData{
@@ -560,7 +560,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered i-data ignores duplicate fsn with different tsn", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete := rq.push(&chunkPayloadData{
@@ -611,7 +611,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered i-data ignores stale incomplete mid after read advances nextMID", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete, err := rq.pushWithError(&chunkPayloadData{
@@ -676,7 +676,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered i-data ignores stale complete mid after read advances nextMID", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete, err := rq.pushWithError(&chunkPayloadData{
@@ -720,7 +720,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("unordered i-data ignores duplicate fsn with different tsn", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete := rq.push(&chunkPayloadData{
@@ -788,7 +788,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("forwardTSN for ordered i-data drops incomplete mids and advances nextMID", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete := rq.push(&chunkPayloadData{
@@ -839,7 +839,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered i-data ignores stale mids after forwardTSN advances nextMID", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		rq.forwardTSNForOrderedMID(1)
@@ -902,7 +902,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("forwardTSN for unordered i-data keeps complete mids and drops old incomplete mids", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete := rq.push(&chunkPayloadData{
@@ -990,15 +990,16 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered i-data rejects new mids after descriptor limit", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		const limit = maxReassemblyQueueMIDEntries
+		rq := newReassemblyQueue(0, reassemblyMIDLimitBytesPerEntry*limit) // cap = limit
 
-		for i := range maxReassemblyQueueMIDEntries {
+		for i := range limit {
 			complete, err := rq.pushWithError(&chunkPayloadData{
 				iData:                  true,
-				messageIdentifier:      uint32(i), //nolint:gosec // bounded by maxReassemblyQueueMIDEntries
+				messageIdentifier:      uint32(i), //nolint:gosec // bounded by limit
 				fragmentSequenceNumber: 0,
 				beginningFragment:      true,
-				tsn:                    uint32(i + 1), //nolint:gosec // bounded by maxReassemblyQueueMIDEntries
+				tsn:                    uint32(i + 1), //nolint:gosec // bounded by limit
 				streamIdentifier:       0,
 				payloadType:            PayloadTypeWebRTCBinary,
 			})
@@ -1011,7 +1012,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 			messageIdentifier:      0,
 			fragmentSequenceNumber: 1,
 			endingFragment:         true,
-			tsn:                    maxReassemblyQueueMIDEntries + 1,
+			tsn:                    limit + 1,
 			streamIdentifier:       0,
 			payloadType:            PayloadTypeWebRTCBinary,
 		})
@@ -1020,22 +1021,22 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 
 		complete, err = rq.pushWithError(&chunkPayloadData{
 			iData:                  true,
-			messageIdentifier:      maxReassemblyQueueMIDEntries,
+			messageIdentifier:      limit,
 			fragmentSequenceNumber: 0,
 			beginningFragment:      true,
-			tsn:                    maxReassemblyQueueMIDEntries + 2,
+			tsn:                    limit + 2,
 			streamIdentifier:       0,
 			payloadType:            PayloadTypeWebRTCBinary,
 		})
 		assert.ErrorIs(t, err, errReassemblyQueueMIDLimitExceeded)
 		assert.False(t, complete, "new MID should be rejected")
-		assert.Len(t, rq.orderedMIDMap, maxReassemblyQueueMIDEntries)
-		assert.Len(t, rq.orderedMID, maxReassemblyQueueMIDEntries)
+		assert.Len(t, rq.orderedMIDMap, limit)
+		assert.Len(t, rq.orderedMID, limit)
 		assert.Equal(t, 0, rq.getNumBytes(), "zero-byte fragments must not hide descriptor growth")
 	})
 
 	t.Run("ordered i-data inserts new mids in order", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		rq := newReassemblyQueue(0, initialRecvBufSize)
 
 		for i, mid := range []uint32{3, 1, 2} {
 			complete, err := rq.pushWithError(&chunkPayloadData{
@@ -1060,16 +1061,17 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("unordered i-data rejects new incomplete mids after descriptor limit", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		const limit = maxReassemblyQueueMIDEntries
+		rq := newReassemblyQueue(0, reassemblyMIDLimitBytesPerEntry*limit) // cap = limit
 
-		for i := range maxReassemblyQueueMIDEntries {
+		for i := range limit {
 			complete, err := rq.pushWithError(&chunkPayloadData{
 				iData:                  true,
 				unordered:              true,
-				messageIdentifier:      uint32(i), //nolint:gosec // bounded by maxReassemblyQueueMIDEntries
+				messageIdentifier:      uint32(i), //nolint:gosec // bounded by limit
 				fragmentSequenceNumber: 0,
 				beginningFragment:      true,
-				tsn:                    uint32(i + 1), //nolint:gosec // bounded by maxReassemblyQueueMIDEntries
+				tsn:                    uint32(i + 1), //nolint:gosec // bounded by limit
 				streamIdentifier:       0,
 				payloadType:            PayloadTypeWebRTCBinary,
 			})
@@ -1080,32 +1082,33 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 		complete, err := rq.pushWithError(&chunkPayloadData{
 			iData:                  true,
 			unordered:              true,
-			messageIdentifier:      maxReassemblyQueueMIDEntries,
+			messageIdentifier:      limit,
 			fragmentSequenceNumber: 0,
 			beginningFragment:      true,
-			tsn:                    maxReassemblyQueueMIDEntries + 1,
+			tsn:                    limit + 1,
 			streamIdentifier:       0,
 			payloadType:            PayloadTypeWebRTCBinary,
 		})
 		assert.ErrorIs(t, err, errReassemblyQueueMIDLimitExceeded)
 		assert.False(t, complete, "new MID should be rejected")
-		assert.Len(t, rq.unorderedMIDMap, maxReassemblyQueueMIDEntries)
+		assert.Len(t, rq.unorderedMIDMap, limit)
 		assert.Len(t, rq.unorderedMID, 0)
 		assert.Equal(t, 0, rq.getNumBytes(), "zero-byte fragments must not hide descriptor growth")
 	})
 
 	t.Run("unordered i-data counts complete queued mids against descriptor limit", func(t *testing.T) {
-		rq := newReassemblyQueue(0)
+		const limit = maxReassemblyQueueMIDEntries
+		rq := newReassemblyQueue(0, reassemblyMIDLimitBytesPerEntry*limit) // cap = limit
 
-		for i := range maxReassemblyQueueMIDEntries {
+		for i := range limit {
 			complete, err := rq.pushWithError(&chunkPayloadData{
 				iData:                  true,
 				unordered:              true,
-				messageIdentifier:      uint32(i), //nolint:gosec // bounded by maxReassemblyQueueMIDEntries
+				messageIdentifier:      uint32(i), //nolint:gosec // bounded by limit
 				fragmentSequenceNumber: 0,
 				beginningFragment:      true,
 				endingFragment:         true,
-				tsn:                    uint32(i + 1), //nolint:gosec // bounded by maxReassemblyQueueMIDEntries
+				tsn:                    uint32(i + 1), //nolint:gosec // bounded by limit
 				streamIdentifier:       0,
 				payloadType:            PayloadTypeWebRTCBinary,
 			})
@@ -1116,18 +1119,18 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 		complete, err := rq.pushWithError(&chunkPayloadData{
 			iData:                  true,
 			unordered:              true,
-			messageIdentifier:      maxReassemblyQueueMIDEntries,
+			messageIdentifier:      limit,
 			fragmentSequenceNumber: 0,
 			beginningFragment:      true,
 			endingFragment:         true,
-			tsn:                    maxReassemblyQueueMIDEntries + 1,
+			tsn:                    limit + 1,
 			streamIdentifier:       0,
 			payloadType:            PayloadTypeWebRTCBinary,
 		})
 		assert.ErrorIs(t, err, errReassemblyQueueMIDLimitExceeded)
 		assert.False(t, complete, "new MID should be rejected")
 		assert.Len(t, rq.unorderedMIDMap, 0)
-		assert.Len(t, rq.unorderedMID, maxReassemblyQueueMIDEntries)
+		assert.Len(t, rq.unorderedMID, limit)
 		assert.Equal(t, 0, rq.getNumBytes(), "zero-byte messages must not hide descriptor growth")
 	})
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -15,7 +15,7 @@ func newTestStream(t *testing.T) *Stream {
 	t.Helper()
 
 	s := &Stream{
-		reassemblyQueue: newReassemblyQueue(0),
+		reassemblyQueue: newReassemblyQueue(0, initialRecvBufSize),
 		log:             logging.NewDefaultLoggerFactory().NewLogger("sctp-test"),
 	}
 	s.readNotifier = sync.NewCond(&s.lock)


### PR DESCRIPTION
#### Description

A lost reliable message or slow application reader could cause
receiver exceeds the fixed 1024 cap of reassemble queue when
network capacity is high. Adjusting this limit to a value based
on the rwnd size to mitigate this issue.
