### PR TITLE
Configurable optin reassembly queue limit for DATA / I-DATA and make it optional / optin

### DIFF
--- a/association.go
+++ b/association.go
@@ -270,17 +270,18 @@ type Association struct {
 	recvZeroChecksum        bool
 
 	// Congestion control parameters
-	maxReceiveBufferSize uint32
-	maxMessageSize       uint32
-	cwnd                 uint32 // my congestion window size
-	rwnd                 uint32 // calculated peer's receiver windows size
-	ssthresh             uint32 // slow start threshold
-	partialBytesAcked    uint32
-	inFastRecovery       bool
-	fastRecoverExitPoint uint32
-	minCwnd              uint32 // Minimum congestion window
-	fastRtxWnd           uint32 // Send window for fast retransmit
-	cwndCAStep           uint32 // Step of congestion window increase at Congestion Avoidance
+	maxReceiveBufferSize      uint32
+	maxMessageSize            uint32
+	maxReassemblyQueueEntries uint32
+	cwnd                      uint32 // my congestion window size
+	rwnd                      uint32 // calculated peer's receiver windows size
+	ssthresh                  uint32 // slow start threshold
+	partialBytesAcked         uint32
+	inFastRecovery            bool
+	fastRecoverExitPoint      uint32
+	minCwnd                   uint32 // Minimum congestion window
+	fastRtxWnd                uint32 // Send window for fast retransmit
+	cwndCAStep                uint32 // Step of congestion window increase at Congestion Avoidance
 
 	// RTX & Ack timer
 	rtoMgr     *rtoManager
@@ -389,6 +390,9 @@ type Config struct {
 
 	// User message interleaving config options
 	interleaving *interleavingSettings
+
+	// Reassembly queue config options
+	maxReassemblyQueueEntries uint32
 
 	// SNAP/sctp-init
 	snapConfig *snapConfig
@@ -558,6 +562,9 @@ func (c Config) applyServer(cfg *Config) error { //nolint:dupl,cyclop
 	if c.MaxMessageSize != 0 {
 		cfg.MaxMessageSize = c.MaxMessageSize
 	}
+	if c.maxReassemblyQueueEntries != 0 {
+		cfg.maxReassemblyQueueEntries = c.maxReassemblyQueueEntries
+	}
 	if c.RTOMax != 0 {
 		cfg.RTOMax = c.RTOMax
 	}
@@ -671,6 +678,9 @@ func (c Config) applyClient(cfg *Config) error { //nolint:dupl,cyclop
 	if c.MaxMessageSize != 0 {
 		cfg.MaxMessageSize = c.MaxMessageSize
 	}
+	if c.maxReassemblyQueueEntries != 0 {
+		cfg.maxReassemblyQueueEntries = c.maxReassemblyQueueEntries
+	}
 	if c.RTOMax != 0 {
 		cfg.RTOMax = c.RTOMax
 	}
@@ -748,12 +758,13 @@ func createAssociationFromConfigWithTsn(cfg *Config, tsn uint32) *Association {
 	}
 
 	assoc := &Association{
-		netConn:              cfg.NetConn,
-		maxReceiveBufferSize: maxReceiveBufferSize,
-		maxMessageSize:       maxMessageSize,
-		minCwnd:              cfg.MinCwnd,
-		fastRtxWnd:           cfg.FastRtxWnd,
-		cwndCAStep:           cfg.CwndCAStep,
+		netConn:                   cfg.NetConn,
+		maxReceiveBufferSize:      maxReceiveBufferSize,
+		maxMessageSize:            maxMessageSize,
+		maxReassemblyQueueEntries: cfg.maxReassemblyQueueEntries,
+		minCwnd:                   cfg.MinCwnd,
+		fastRtxWnd:                cfg.FastRtxWnd,
+		cwndCAStep:                cfg.CwndCAStep,
 
 		myMaxNumOutboundStreams: math.MaxUint16,
 		myMaxNumInboundStreams:  math.MaxUint16,
@@ -2444,10 +2455,13 @@ func (a *Association) createStream(streamIdentifier uint16, accept bool) *Stream
 	stream := &Stream{
 		association:      a,
 		streamIdentifier: streamIdentifier,
-		reassemblyQueue:  newReassemblyQueue(streamIdentifier, a.maxReceiveBufferSize),
-		log:              a.log,
-		name:             fmt.Sprintf("%d:%s", streamIdentifier, a.name),
-		writeDeadline:    deadline.New(),
+		reassemblyQueue: newReassemblyQueue(
+			streamIdentifier,
+			a.maxReassemblyQueueEntries,
+		),
+		log:           a.log,
+		name:          fmt.Sprintf("%d:%s", streamIdentifier, a.name),
+		writeDeadline: deadline.New(),
 	}
 
 	stream.readNotifier = sync.NewCond(&stream.lock)

--- a/association_options.go
+++ b/association_options.go
@@ -136,6 +136,16 @@ func WithMaxMessageSize(size uint32) AssociationOption {
 	})
 }
 
+// WithMaxReassemblyQueueEntries caps the number of DATA entries and I-DATA MIDs queued per stream.
+// A value of 0 disables the cap. By default this cap is disabled.
+func WithMaxReassemblyQueueEntries(maxEntries uint32) AssociationOption {
+	return sharedOption(func(c *Config) error {
+		c.maxReassemblyQueueEntries = maxEntries
+
+		return nil
+	})
+}
+
 // WithRTOMax sets the max retransmission timeout in ms for the association.
 func WithRTOMax(rtoMax float64) AssociationOption {
 	return sharedOption(func(c *Config) error {

--- a/association_options_test.go
+++ b/association_options_test.go
@@ -20,16 +20,23 @@ func udpPiper(t *testing.T) (net.Conn, net.Conn) {
 }
 
 func TestAssociationOptions_ApplyBothSides(t *testing.T) {
-	opt := WithName("x")
+	opts := []AssociationOption{
+		WithName("x"),
+		WithMaxReassemblyQueueEntries(13),
+	}
 
 	var sCfg Config
 	var cCfg Config
 
-	assert.NoError(t, opt.applyServer(&sCfg))
-	assert.NoError(t, opt.applyClient(&cCfg))
+	for _, opt := range opts {
+		assert.NoError(t, opt.applyServer(&sCfg))
+		assert.NoError(t, opt.applyClient(&cCfg))
+	}
 
 	assert.Equal(t, "x", sCfg.Name)
 	assert.Equal(t, "x", cCfg.Name)
+	assert.Equal(t, uint32(13), sCfg.maxReassemblyQueueEntries)
+	assert.Equal(t, uint32(13), cCfg.maxReassemblyQueueEntries)
 }
 
 func TestConfigComparable(t *testing.T) {
@@ -164,6 +171,7 @@ func TestAssociationOptions_ClientAndServer(t *testing.T) {
 		WithMTU(1200),
 		WithMaxReceiveBufferSize(7777),
 		WithMaxMessageSize(30000),
+		WithMaxReassemblyQueueEntries(13),
 		WithRTOMax(1000),
 		WithMinCwnd(5000),
 		WithFastRtxWnd(6000),
@@ -191,6 +199,9 @@ func TestAssociationOptions_ClientAndServer(t *testing.T) {
 
 	assert.Equal(t, uint32(30000), aClient.MaxMessageSize())
 	assert.Equal(t, uint32(30000), aServer.MaxMessageSize())
+
+	assert.Equal(t, uint32(13), aClient.maxReassemblyQueueEntries)
+	assert.Equal(t, uint32(13), aServer.maxReassemblyQueueEntries)
 
 	assert.Equal(t, uint32(5000), aClient.minCwnd)
 	assert.Equal(t, uint32(6000), aClient.fastRtxWnd)

--- a/association_test.go
+++ b/association_test.go
@@ -1122,9 +1122,8 @@ func TestAssociationIForwardTSNDuplicateEntriesUseLargestMID(t *testing.T) {
 }
 
 func TestAssociationInterleavingProtocolViolationMIDLimit(t *testing.T) {
-	const limit = maxReassemblyQueueMIDEntries
-	// receive buffer sized so the derived MID cap is exactly limit
-	assoc := createTestAssociation(t, Config{MaxReceiveBufferSize: reassemblyMIDLimitBytesPerEntry * limit})
+	const limit = 3
+	assoc := createTestAssociationWithOptions(t, Config{}, WithMaxReassemblyQueueEntries(limit))
 	assoc.useInterleaving = true
 	assoc.payloadQueue.init(0)
 	assoc.setState(established)
@@ -1132,10 +1131,10 @@ func TestAssociationInterleavingProtocolViolationMIDLimit(t *testing.T) {
 	for i := range limit {
 		packets := assoc.handleData(&chunkPayloadData{
 			iData:                  true,
-			messageIdentifier:      uint32(i), //nolint:gosec // bounded by maxReassemblyQueueMIDEntries
+			messageIdentifier:      uint32(i), //nolint:gosec // bounded by limit
 			fragmentSequenceNumber: 0,
 			beginningFragment:      true,
-			tsn:                    uint32(i + 1), //nolint:gosec // bounded by maxReassemblyQueueMIDEntries
+			tsn:                    uint32(i + 1), //nolint:gosec // bounded by limit
 			streamIdentifier:       1,
 			payloadType:            PayloadTypeWebRTCBinary,
 		})
@@ -1158,6 +1157,61 @@ func TestAssociationInterleavingProtocolViolationMIDLimit(t *testing.T) {
 	cause, ok := assoc.willSendAbortCause.(*errorCauseProtocolViolation)
 	require.True(t, ok, "abort cause should be a protocol violation")
 	assert.Equal(t, errReassemblyQueueMIDLimitExceeded.Error(), string(cause.additionalInformation))
+}
+
+func TestAssociationInterleavingMIDLimitDisabledByDefault(t *testing.T) {
+	const oldLimit = 3
+	assoc := createTestAssociation(t, Config{})
+	assoc.useInterleaving = true
+	assoc.payloadQueue.init(0)
+	assoc.setState(established)
+
+	for i := range oldLimit + 1 {
+		packets := assoc.handleData(&chunkPayloadData{
+			iData:                  true,
+			messageIdentifier:      uint32(i), //nolint:gosec // bounded by oldLimit
+			fragmentSequenceNumber: 0,
+			beginningFragment:      true,
+			tsn:                    uint32(i + 1), //nolint:gosec // bounded by oldLimit
+			streamIdentifier:       1,
+			payloadType:            PayloadTypeWebRTCBinary,
+		})
+		require.Nil(t, packets)
+		require.False(t, assoc.willSendAbort, "association should not abort when the MID limit is disabled")
+	}
+}
+
+func TestAssociationDataReassemblyLimitProtocolViolation(t *testing.T) {
+	const limit = 3
+	assoc := createTestAssociationWithOptions(t, Config{}, WithMaxReassemblyQueueEntries(limit))
+	assoc.payloadQueue.init(0)
+	assoc.setState(established)
+
+	for i := range limit {
+		packets := assoc.handleData(&chunkPayloadData{
+			streamSequenceNumber: uint16(i), //nolint:gosec // bounded by limit
+			beginningFragment:    true,
+			tsn:                  uint32(i + 1), //nolint:gosec // bounded by limit
+			streamIdentifier:     1,
+			payloadType:          PayloadTypeWebRTCBinary,
+		})
+		require.Nil(t, packets)
+		require.False(t, assoc.willSendAbort, "association should remain open below the DATA limit")
+	}
+
+	packets := assoc.handleData(&chunkPayloadData{
+		streamSequenceNumber: limit,
+		beginningFragment:    true,
+		tsn:                  limit + 1,
+		streamIdentifier:     1,
+		payloadType:          PayloadTypeWebRTCBinary,
+	})
+	require.Nil(t, packets)
+	require.True(t, assoc.willSendAbort, "association should abort on a new DATA entry over the limit")
+
+	cause, ok := assoc.willSendAbortCause.(*errorCauseProtocolViolation)
+	require.True(t, ok, "abort cause should be a protocol violation")
+	assert.Equal(t, errReassemblyQueueLimitExceeded.Error(), string(cause.additionalInformation))
 }
 
 func TestAssocReliable(t *testing.T) { //nolint:maintidx
@@ -1983,6 +2037,12 @@ loop1:
 func createTestAssociation(t *testing.T, cfg Config) *Association {
 	t.Helper()
 
+	return createTestAssociationWithOptions(t, cfg)
+}
+
+func createTestAssociationWithOptions(t *testing.T, cfg Config, opts ...AssociationOption) *Association {
+	t.Helper()
+
 	if cfg.NetConn == nil {
 		cfg.NetConn = &dumbConn{}
 	}
@@ -1990,7 +2050,13 @@ func createTestAssociation(t *testing.T, cfg Config) *Association {
 		cfg.LoggerFactory = logging.NewDefaultLoggerFactory()
 	}
 
-	a, err := createServerAssociation(cfg)
+	serverOpts := make([]ServerOption, 0, len(opts)+1)
+	serverOpts = append(serverOpts, cfg)
+	for _, opt := range opts {
+		serverOpts = append(serverOpts, opt)
+	}
+
+	a, err := createServerAssociation(serverOpts...)
 	require.NoError(t, err)
 
 	return a

--- a/reassembly_queue.go
+++ b/reassembly_queue.go
@@ -57,12 +57,14 @@ func newChunkSet(ssn uint16, ppi PayloadProtocolIdentifier) *chunkSet {
 
 func (set *chunkSet) push(chunk *chunkPayloadData) bool {
 	// check if dup
-	for _, c := range set.chunks {
-		if c.tsn == chunk.tsn {
-			return false
-		}
+	if set.hasTSN(chunk.tsn) {
+		return false
 	}
 
+	return set.pushNoDuplicate(chunk)
+}
+
+func (set *chunkSet) pushNoDuplicate(chunk *chunkPayloadData) bool {
 	// append and sort
 	set.chunks = append(set.chunks, chunk)
 	sortChunksByTSN(set.chunks)
@@ -71,6 +73,16 @@ func (set *chunkSet) push(chunk *chunkPayloadData) bool {
 	complete := set.isComplete()
 
 	return complete
+}
+
+func (set *chunkSet) hasTSN(tsn uint32) bool {
+	for _, c := range set.chunks {
+		if c.tsn == tsn {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (set *chunkSet) isComplete() bool {
@@ -197,29 +209,18 @@ type reassemblyQueue struct {
 	unorderedMIDMap map[uint32]*chunkSetMID
 	useInterleaving bool
 	nBytes          uint64
-	maxMIDEntries   int
+	maxEntries      uint32
 }
 
 var (
 	errTryAgain = errors.New("try again")
 
+	errReassemblyQueueLimitExceeded = errors.New("reassembly queue data limit exceeded")
+
 	errReassemblyQueueMIDLimitExceeded = errors.New("reassembly queue i-data message identifier limit exceeded")
 )
 
-const (
-	// reassemblyMIDLimitBytesPerEntry is the receive-buffer budget allotted per
-	// undelivered interleaved (i-data) message. The MID-entry cap is
-	// maxReceiveBufferSize/reassemblyMIDLimitBytesPerEntry, so reassembly memory
-	// scales with the configured buffer. the cap only bites pathological floods of tiny or
-	// header-only messages that a_rwnd cannot bound.
-	reassemblyMIDLimitBytesPerEntry = 64
-
-	maxReassemblyQueueMIDEntries = 1024
-)
-
-func newReassemblyQueue(si uint16, maxReceiveBufferSize uint32) *reassemblyQueue {
-	maxMIDEntries := max(int(maxReceiveBufferSize/reassemblyMIDLimitBytesPerEntry), maxReassemblyQueueMIDEntries)
-
+func newReassemblyQueue(si uint16, maxEntries uint32) *reassemblyQueue {
 	// From RFC 4960 Sec 6.5:
 	//   The Stream Sequence Number in all the streams MUST start from 0 when
 	//   the association is established.  Also, when the Stream Sequence
@@ -235,8 +236,42 @@ func newReassemblyQueue(si uint16, maxReceiveBufferSize uint32) *reassemblyQueue
 		unorderedMID:    make([]*chunkSetMID, 0),
 		orderedMIDMap:   map[uint32]*chunkSetMID{},
 		unorderedMIDMap: map[uint32]*chunkSetMID{},
-		maxMIDEntries:   maxMIDEntries,
+		maxEntries:      maxEntries,
 	}
+}
+
+func isReassemblyQueueLimitReached(maxEntries uint32, nEntries int) bool {
+	return maxEntries > 0 && int64(nEntries) >= int64(maxEntries)
+}
+
+func (r *reassemblyQueue) isDataLimitReached(nEntries int) bool {
+	return isReassemblyQueueLimitReached(r.maxEntries, nEntries)
+}
+
+func (r *reassemblyQueue) hasDataLimit() bool {
+	return r.maxEntries > 0
+}
+
+func (r *reassemblyQueue) isMIDLimitReached(nEntries int) bool {
+	return isReassemblyQueueLimitReached(r.maxEntries, nEntries)
+}
+
+func (r *reassemblyQueue) orderedDataEntryCount() int {
+	nEntries := 0
+	for _, set := range r.ordered {
+		nEntries += len(set.chunks)
+	}
+
+	return nEntries
+}
+
+func (r *reassemblyQueue) unorderedDataEntryCount() int {
+	nEntries := len(r.unorderedChunks)
+	for _, set := range r.unordered {
+		nEntries += len(set.chunks)
+	}
+
+	return nEntries
 }
 
 func (r *reassemblyQueue) push(chunk *chunkPayloadData) bool {
@@ -259,6 +294,10 @@ func (r *reassemblyQueue) pushWithError(chunk *chunkPayloadData) (bool, error) {
 	}
 
 	if chunk.unordered {
+		if r.hasDataLimit() && r.isDataLimitReached(r.unorderedDataEntryCount()) {
+			return false, errReassemblyQueueLimitExceeded
+		}
+
 		// First, insert into unorderedChunks array
 		r.unorderedChunks = append(r.unorderedChunks, chunk)
 		atomic.AddUint64(&r.nBytes, uint64(len(chunk.userData)))
@@ -303,7 +342,13 @@ func (r *reassemblyQueue) pushWithError(chunk *chunkPayloadData) (bool, error) {
 		}
 	}
 
-	// If not found, create a new chunkSet
+	// Reject a new queued DATA entry once the descriptor cap is reached.
+	if cset != nil && cset.hasTSN(chunk.tsn) {
+		return false, nil
+	}
+	if r.hasDataLimit() && r.isDataLimitReached(r.orderedDataEntryCount()) {
+		return false, errReassemblyQueueLimitExceeded
+	}
 	if cset == nil {
 		cset = newChunkSet(chunk.streamSequenceNumber, chunk.payloadType)
 		r.ordered = append(r.ordered, cset)
@@ -314,7 +359,7 @@ func (r *reassemblyQueue) pushWithError(chunk *chunkPayloadData) (bool, error) {
 
 	atomic.AddUint64(&r.nBytes, uint64(len(chunk.userData)))
 
-	return cset.push(chunk), nil
+	return cset.pushNoDuplicate(chunk), nil
 }
 
 func (r *reassemblyQueue) pushIData(chunk *chunkPayloadData) (bool, error) {
@@ -339,7 +384,7 @@ func (r *reassemblyQueue) pushUnorderedIData(chunk *chunkPayloadData) (bool, err
 	}
 	cset := r.unorderedMIDMap[chunk.messageIdentifier]
 	if cset == nil {
-		if r.unorderedMIDEntryCount() >= r.maxMIDEntries {
+		if r.isMIDLimitReached(r.unorderedMIDEntryCount()) {
 			return false, errReassemblyQueueMIDLimitExceeded
 		}
 		cset = newChunkSetMID(chunk.messageIdentifier, chunk.payloadType)
@@ -372,7 +417,7 @@ func (r *reassemblyQueue) pushOrderedIData(chunk *chunkPayloadData) (bool, error
 	}
 	cset := r.orderedMIDMap[chunk.messageIdentifier]
 	if cset == nil {
-		if len(r.orderedMIDMap) >= r.maxMIDEntries {
+		if r.isMIDLimitReached(len(r.orderedMIDMap)) {
 			return false, errReassemblyQueueMIDLimitExceeded
 		}
 		cset = newChunkSetMID(chunk.messageIdentifier, chunk.payloadType)

--- a/reassembly_queue_test.go
+++ b/reassembly_queue_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
+func TestReassemblyQueue(t *testing.T) { //nolint:maintidx,cyclop
 	t.Run("ordered fragments", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -54,7 +54,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered fragments", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -110,7 +110,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered and unordered in the mix", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -168,7 +168,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("unordered complete skips incomplete", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -231,7 +231,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ignores chunk with wrong SI", func(t *testing.T) {
-		rq := newReassemblyQueue(123, initialRecvBufSize)
+		rq := newReassemblyQueue(123, 0)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -254,7 +254,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ignores chunk with stale SSN", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 		rq.nextSSN = 7 // forcibly set expected SSN to 7
 
 		orgPpi := PayloadTypeWebRTCBinary
@@ -277,7 +277,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("should fail to read incomplete chunk", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -303,7 +303,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("should fail to read if the next SSN is not ready", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -330,7 +330,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("detect buffer too short", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		for _, chunk := range []*chunkPayloadData{
@@ -374,7 +374,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("forwardTSN for ordered fragments", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -426,7 +426,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("forwardTSN for unordered fragments", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -483,7 +483,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("fragmented and unfragmented chunks with the same ssn", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 
 		orgPpi := PayloadTypeWebRTCBinary
 
@@ -520,8 +520,189 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 		assert.Equal(t, 6, rq.getNumBytes(), "num bytes mismatch")
 	})
 
+	t.Run("ordered data has no descriptor limit by default", func(t *testing.T) {
+		const oldLimit = 3
+		rq := newReassemblyQueue(0, 0)
+
+		for i := range oldLimit + 1 {
+			complete, err := rq.pushWithError(&chunkPayloadData{
+				streamSequenceNumber: uint16(i), //nolint:gosec // bounded by oldLimit
+				beginningFragment:    true,
+				tsn:                  uint32(i + 1), //nolint:gosec // bounded by oldLimit
+				streamIdentifier:     0,
+				payloadType:          PayloadTypeWebRTCBinary,
+			})
+			assert.NoError(t, err)
+			assert.False(t, complete, "SSN should remain incomplete")
+		}
+
+		assert.Len(t, rq.ordered, oldLimit+1)
+	})
+
+	t.Run("ordered data rejects new entries after descriptor limit", func(t *testing.T) {
+		const limit = 3
+		rq := newReassemblyQueue(0, limit)
+
+		for i := range limit {
+			complete, err := rq.pushWithError(&chunkPayloadData{
+				streamSequenceNumber: uint16(i), //nolint:gosec // bounded by limit
+				beginningFragment:    true,
+				tsn:                  uint32(i*10 + 1), //nolint:gosec // bounded by limit
+				streamIdentifier:     0,
+				payloadType:          PayloadTypeWebRTCBinary,
+			})
+			assert.NoError(t, err)
+			assert.False(t, complete, "SSN should remain incomplete")
+		}
+
+		complete, err := rq.pushWithError(&chunkPayloadData{
+			streamSequenceNumber: 0,
+			beginningFragment:    true,
+			tsn:                  1,
+			streamIdentifier:     0,
+			payloadType:          PayloadTypeWebRTCBinary,
+		})
+		assert.NoError(t, err, "duplicate fragments should not be rejected at the limit")
+		assert.False(t, complete, "duplicate fragments should not complete")
+
+		complete, err = rq.pushWithError(&chunkPayloadData{
+			streamSequenceNumber: 0,
+			endingFragment:       true,
+			tsn:                  2,
+			streamIdentifier:     0,
+			payloadType:          PayloadTypeWebRTCBinary,
+		})
+		assert.ErrorIs(t, err, errReassemblyQueueLimitExceeded)
+		assert.False(t, complete, "new fragments for existing SSNs should be rejected at the limit")
+
+		complete, err = rq.pushWithError(&chunkPayloadData{
+			streamSequenceNumber: limit,
+			beginningFragment:    true,
+			tsn:                  limit*10 + 1,
+			streamIdentifier:     0,
+			payloadType:          PayloadTypeWebRTCBinary,
+		})
+		assert.ErrorIs(t, err, errReassemblyQueueLimitExceeded)
+		assert.False(t, complete, "new SSN should be rejected")
+		assert.Len(t, rq.ordered, limit)
+		assert.Equal(t, limit, rq.orderedDataEntryCount())
+	})
+
+	t.Run("unordered data has no descriptor limit by default", func(t *testing.T) {
+		const oldLimit = 3
+		rq := newReassemblyQueue(0, 0)
+
+		for i := range oldLimit + 1 {
+			complete, err := rq.pushWithError(&chunkPayloadData{
+				unordered:         true,
+				beginningFragment: true,
+				tsn:               uint32(i + 1), //nolint:gosec // bounded by oldLimit
+				streamIdentifier:  0,
+				payloadType:       PayloadTypeWebRTCBinary,
+			})
+			assert.NoError(t, err)
+			assert.False(t, complete, "unordered DATA should remain incomplete")
+		}
+
+		assert.Len(t, rq.unorderedChunks, oldLimit+1)
+		assert.Len(t, rq.unordered, 0)
+	})
+
+	t.Run("unordered data rejects new incomplete chunks after descriptor limit", func(t *testing.T) {
+		const limit = 3
+		rq := newReassemblyQueue(0, limit)
+
+		for i := range limit {
+			complete, err := rq.pushWithError(&chunkPayloadData{
+				unordered:         true,
+				beginningFragment: true,
+				tsn:               uint32(i + 1), //nolint:gosec // bounded by limit
+				streamIdentifier:  0,
+				payloadType:       PayloadTypeWebRTCBinary,
+			})
+			assert.NoError(t, err)
+			assert.False(t, complete, "unordered DATA should remain incomplete")
+		}
+
+		complete, err := rq.pushWithError(&chunkPayloadData{
+			unordered:         true,
+			beginningFragment: true,
+			tsn:               limit + 1,
+			streamIdentifier:  0,
+			payloadType:       PayloadTypeWebRTCBinary,
+		})
+		assert.ErrorIs(t, err, errReassemblyQueueLimitExceeded)
+		assert.False(t, complete, "new unordered DATA chunk should be rejected")
+		assert.Len(t, rq.unorderedChunks, limit)
+		assert.Len(t, rq.unordered, 0)
+	})
+
+	t.Run("unordered data counts complete queued sets against descriptor limit", func(t *testing.T) {
+		const limit = 3
+		rq := newReassemblyQueue(0, limit)
+
+		for i := range limit {
+			complete, err := rq.pushWithError(&chunkPayloadData{
+				unordered:         true,
+				beginningFragment: true,
+				endingFragment:    true,
+				tsn:               uint32(i + 1), //nolint:gosec // bounded by limit
+				streamIdentifier:  0,
+				payloadType:       PayloadTypeWebRTCBinary,
+			})
+			assert.NoError(t, err)
+			assert.True(t, complete, "unordered DATA should complete")
+		}
+
+		complete, err := rq.pushWithError(&chunkPayloadData{
+			unordered:         true,
+			beginningFragment: true,
+			endingFragment:    true,
+			tsn:               limit + 1,
+			streamIdentifier:  0,
+			payloadType:       PayloadTypeWebRTCBinary,
+		})
+		assert.ErrorIs(t, err, errReassemblyQueueLimitExceeded)
+		assert.False(t, complete, "new unordered DATA set should be rejected")
+		assert.Len(t, rq.unorderedChunks, 0)
+		assert.Len(t, rq.unordered, limit)
+		assert.Equal(t, limit, rq.unorderedDataEntryCount())
+	})
+
+	t.Run("unordered data counts complete queued set fragments against descriptor limit", func(t *testing.T) {
+		const limit = 3
+		rq := newReassemblyQueue(0, limit)
+
+		for i := range limit {
+			complete, err := rq.pushWithError(&chunkPayloadData{
+				unordered:         true,
+				beginningFragment: i == 0,
+				endingFragment:    i == limit-1,
+				tsn:               uint32(i + 1), //nolint:gosec // bounded by limit
+				streamIdentifier:  0,
+				payloadType:       PayloadTypeWebRTCBinary,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, i == limit-1, complete)
+		}
+
+		complete, err := rq.pushWithError(&chunkPayloadData{
+			unordered:         true,
+			beginningFragment: true,
+			endingFragment:    true,
+			tsn:               limit + 1,
+			streamIdentifier:  0,
+			payloadType:       PayloadTypeWebRTCBinary,
+		})
+		assert.ErrorIs(t, err, errReassemblyQueueLimitExceeded)
+		assert.False(t, complete, "new unordered DATA set should be rejected")
+		assert.Len(t, rq.unorderedChunks, 0)
+		assert.Len(t, rq.unordered, 1)
+		assert.Equal(t, limit, rq.unorderedDataEntryCount())
+	})
+
 	t.Run("i-data ordered fragments by fsn", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		chunk1 := &chunkPayloadData{
@@ -560,7 +741,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered i-data ignores duplicate fsn with different tsn", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete := rq.push(&chunkPayloadData{
@@ -611,7 +792,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered i-data ignores stale incomplete mid after read advances nextMID", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete, err := rq.pushWithError(&chunkPayloadData{
@@ -676,7 +857,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered i-data ignores stale complete mid after read advances nextMID", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete, err := rq.pushWithError(&chunkPayloadData{
@@ -720,7 +901,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("unordered i-data ignores duplicate fsn with different tsn", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete := rq.push(&chunkPayloadData{
@@ -788,7 +969,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("forwardTSN for ordered i-data drops incomplete mids and advances nextMID", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete := rq.push(&chunkPayloadData{
@@ -839,7 +1020,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered i-data ignores stale mids after forwardTSN advances nextMID", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		rq.forwardTSNForOrderedMID(1)
@@ -902,7 +1083,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("forwardTSN for unordered i-data keeps complete mids and drops old incomplete mids", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 		orgPpi := PayloadTypeWebRTCBinary
 
 		complete := rq.push(&chunkPayloadData{
@@ -989,9 +1170,54 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 		assert.False(t, rq.isReadable(), "only an incomplete MID should remain")
 	})
 
+	t.Run("ordered i-data has no descriptor limit by default", func(t *testing.T) {
+		const oldLimit = 3
+		rq := newReassemblyQueue(0, 0)
+
+		for i := range oldLimit + 1 {
+			complete, err := rq.pushWithError(&chunkPayloadData{
+				iData:                  true,
+				messageIdentifier:      uint32(i), //nolint:gosec // bounded by oldLimit
+				fragmentSequenceNumber: 0,
+				beginningFragment:      true,
+				tsn:                    uint32(i + 1), //nolint:gosec // bounded by oldLimit
+				streamIdentifier:       0,
+				payloadType:            PayloadTypeWebRTCBinary,
+			})
+			assert.NoError(t, err)
+			assert.False(t, complete, "MID should remain incomplete")
+		}
+
+		assert.Len(t, rq.orderedMIDMap, oldLimit+1)
+		assert.Len(t, rq.orderedMID, oldLimit+1)
+	})
+
+	t.Run("unordered i-data has no descriptor limit by default", func(t *testing.T) {
+		const oldLimit = 3
+		rq := newReassemblyQueue(0, 0)
+
+		for i := range oldLimit + 1 {
+			complete, err := rq.pushWithError(&chunkPayloadData{
+				iData:                  true,
+				unordered:              true,
+				messageIdentifier:      uint32(i), //nolint:gosec // bounded by oldLimit
+				fragmentSequenceNumber: 0,
+				beginningFragment:      true,
+				tsn:                    uint32(i + 1), //nolint:gosec // bounded by oldLimit
+				streamIdentifier:       0,
+				payloadType:            PayloadTypeWebRTCBinary,
+			})
+			assert.NoError(t, err)
+			assert.False(t, complete, "MID should remain incomplete")
+		}
+
+		assert.Len(t, rq.unorderedMIDMap, oldLimit+1)
+		assert.Len(t, rq.unorderedMID, 0)
+	})
+
 	t.Run("ordered i-data rejects new mids after descriptor limit", func(t *testing.T) {
-		const limit = maxReassemblyQueueMIDEntries
-		rq := newReassemblyQueue(0, reassemblyMIDLimitBytesPerEntry*limit) // cap = limit
+		const limit = 3
+		rq := newReassemblyQueue(0, limit)
 
 		for i := range limit {
 			complete, err := rq.pushWithError(&chunkPayloadData{
@@ -1036,7 +1262,7 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("ordered i-data inserts new mids in order", func(t *testing.T) {
-		rq := newReassemblyQueue(0, initialRecvBufSize)
+		rq := newReassemblyQueue(0, 0)
 
 		for i, mid := range []uint32{3, 1, 2} {
 			complete, err := rq.pushWithError(&chunkPayloadData{
@@ -1061,8 +1287,8 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("unordered i-data rejects new incomplete mids after descriptor limit", func(t *testing.T) {
-		const limit = maxReassemblyQueueMIDEntries
-		rq := newReassemblyQueue(0, reassemblyMIDLimitBytesPerEntry*limit) // cap = limit
+		const limit = 3
+		rq := newReassemblyQueue(0, limit)
 
 		for i := range limit {
 			complete, err := rq.pushWithError(&chunkPayloadData{
@@ -1097,8 +1323,8 @@ func TestReassemblyQueue(t *testing.T) { //nolint:maintidx
 	})
 
 	t.Run("unordered i-data counts complete queued mids against descriptor limit", func(t *testing.T) {
-		const limit = maxReassemblyQueueMIDEntries
-		rq := newReassemblyQueue(0, reassemblyMIDLimitBytesPerEntry*limit) // cap = limit
+		const limit = 3
+		rq := newReassemblyQueue(0, limit)
 
 		for i := range limit {
 			complete, err := rq.pushWithError(&chunkPayloadData{

--- a/stream_test.go
+++ b/stream_test.go
@@ -15,7 +15,7 @@ func newTestStream(t *testing.T) *Stream {
 	t.Helper()
 
 	s := &Stream{
-		reassemblyQueue: newReassemblyQueue(0, initialRecvBufSize),
+		reassemblyQueue: newReassemblyQueue(0, 0),
 		log:             logging.NewDefaultLoggerFactory().NewLogger("sctp-test"),
 	}
 	s.readNotifier = sync.NewCond(&s.lock)


### PR DESCRIPTION
#### Description
After discussion in https://discord.com/channels/1352636971591274548/1359189787768258671/1519753476983357531 we decided to make any arbitrary limits or limits not mandated by RFC optional even if they lead to DoS.
This makes the I-DATA queue limit optin (none by default) and applies the same optional limit to DATA queues.
At pion/webrtc we should export a single API to set all the similar limits across Pion at once, and maybe provide profiles, or way to implement fair.

related to https://github.com/pion/sctp/pull/471