### PR TITLE
Export ClientContext

### DIFF
--- a/association.go
+++ b/association.go
@@ -437,11 +437,11 @@ func Client(config Config) (*Association, error) {
 
 // ClientWithOptions opens a SCTP stream over a conn.
 func ClientWithOptions(opts ...ClientOption) (*Association, error) {
-	return createClientWithOptionsWithContext(context.Background(), opts...)
+	return ClientWithOptionsContext(context.Background(), opts...)
 }
 
 func createClientWithContext(ctx context.Context, config Config) (*Association, error) {
-	return createClientWithOptionsWithContext(ctx, config)
+	return ClientWithOptionsContext(ctx, config)
 }
 
 func createSNAPAssociation(config *Config) (*Association, error) {
@@ -464,7 +464,10 @@ func createSNAPAssociation(config *Config) (*Association, error) {
 	return assoc, nil
 }
 
-func createClientWithOptionsWithContext(ctx context.Context, opts ...ClientOption) (*Association, error) {
+// ClientWithOptionsContext opens a SCTP stream over a conn.
+// If ctx is canceled before the SCTP handshake completes, the association is
+// closed and ctx.Err() is returned.
+func ClientWithOptionsContext(ctx context.Context, opts ...ClientOption) (*Association, error) {
 	config, err := buildClientConfig(opts...)
 	if err != nil {
 		return nil, err

--- a/association.go
+++ b/association.go
@@ -437,11 +437,11 @@ func Client(config Config) (*Association, error) {
 
 // ClientWithOptions opens a SCTP stream over a conn.
 func ClientWithOptions(opts ...ClientOption) (*Association, error) {
-	return ClientWithOptionsContext(context.Background(), opts...)
+	return ClientContext(context.Background(), opts...)
 }
 
 func createClientWithContext(ctx context.Context, config Config) (*Association, error) {
-	return ClientWithOptionsContext(ctx, config)
+	return ClientContext(ctx, config)
 }
 
 func createSNAPAssociation(config *Config) (*Association, error) {
@@ -464,10 +464,10 @@ func createSNAPAssociation(config *Config) (*Association, error) {
 	return assoc, nil
 }
 
-// ClientWithOptionsContext opens a SCTP stream over a conn.
+// ClientContext opens a SCTP stream over a conn.
 // If ctx is canceled before the SCTP handshake completes, the association is
 // closed and ctx.Err() is returned.
-func ClientWithOptionsContext(ctx context.Context, opts ...ClientOption) (*Association, error) {
+func ClientContext(ctx context.Context, opts ...ClientOption) (*Association, error) {
 	config, err := buildClientConfig(opts...)
 	if err != nil {
 		return nil, err

--- a/association_test.go
+++ b/association_test.go
@@ -4964,8 +4964,8 @@ func TestAssociation_Abort(t *testing.T) {
 	assert.Error(t, err, "User Initiated Abort: 1234", "expected abort reason")
 }
 
-// TestAssociation_createClientWithContext tests that the client is closed when the context is canceled.
-func TestAssociation_createClientWithContext(t *testing.T) {
+// TestClientWithOptionsContext tests that the client is closed when the context is canceled.
+func TestClientWithOptionsContext(t *testing.T) {
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 5)
 	defer lim.Stop()
@@ -4982,10 +4982,7 @@ func TestAssociation_createClientWithContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 
 	go func() {
-		_, err2 := createClientWithContext(ctx, Config{
-			NetConn:       udp1,
-			LoggerFactory: loggerFactory,
-		})
+		_, err2 := ClientWithOptionsContext(ctx, WithNetConn(udp1), WithLoggerFactory(loggerFactory))
 		if err2 != nil {
 			errCh1 <- err2
 		} else {
@@ -4994,10 +4991,7 @@ func TestAssociation_createClientWithContext(t *testing.T) {
 	}()
 
 	go func() {
-		_, err2 := createClientWithContext(ctx, Config{
-			NetConn:       udp2,
-			LoggerFactory: loggerFactory,
-		})
+		_, err2 := ClientWithOptionsContext(ctx, WithNetConn(udp2), WithLoggerFactory(loggerFactory))
 		if err2 != nil {
 			errCh2 <- err2
 		} else {

--- a/association_test.go
+++ b/association_test.go
@@ -4964,8 +4964,8 @@ func TestAssociation_Abort(t *testing.T) {
 	assert.Error(t, err, "User Initiated Abort: 1234", "expected abort reason")
 }
 
-// TestClientWithOptionsContext tests that the client is closed when the context is canceled.
-func TestClientWithOptionsContext(t *testing.T) {
+// TestClientContext tests that the client is closed when the context is canceled.
+func TestClientContext(t *testing.T) {
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 5)
 	defer lim.Stop()
@@ -4982,7 +4982,7 @@ func TestClientWithOptionsContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 
 	go func() {
-		_, err2 := ClientWithOptionsContext(ctx, WithNetConn(udp1), WithLoggerFactory(loggerFactory))
+		_, err2 := ClientContext(ctx, WithNetConn(udp1), WithLoggerFactory(loggerFactory))
 		if err2 != nil {
 			errCh1 <- err2
 		} else {
@@ -4991,7 +4991,7 @@ func TestClientWithOptionsContext(t *testing.T) {
 	}()
 
 	go func() {
-		_, err2 := ClientWithOptionsContext(ctx, WithNetConn(udp2), WithLoggerFactory(loggerFactory))
+		_, err2 := ClientContext(ctx, WithNetConn(udp2), WithLoggerFactory(loggerFactory))
 		if err2 != nil {
 			errCh2 <- err2
 		} else {


### PR DESCRIPTION
Export `ClientContext(ctx, opts...)` so callers can bound or cancel SCTP connection setup. This enables a follow-up `SCTPTransport.StartContext` API in pion/webrtc without waiting for the full SCTP handshake when a connection attempt is canceled.

The context controls establishment only. Canceling it after successful setup leaves the association open. An already-canceled context starts no association and leaves the supplied connection open. Cancellation during setup returns `ctx.Err()` and closes the association in the background, including the SNAP path, so a blocking connection shutdown cannot stall the caller.

Use the maintainer-requested `ClientContext` name so the API remains consistent when the transitional `WithOptions` constructors are renamed in the next major version. Existing constructors continue to use a background context.

Validation: full Go race suite, focused tests for cancellation/deadlines and connection cleanup, and CI-pinned golangci-lint v2.10.1.
