### PR TITLE
Add bounded SCTP receive resource controls

### DIFF
--- a/association.go
+++ b/association.go
@@ -2332,16 +2332,19 @@ func (a *Association) acceptPayloadData(chunkPayload *chunkPayloadData) bool {
 		a.abortProtocolViolation("inbound stream limit exceeded")
 		return false
 	}
-	if a.maxRetainedPayloadChunks > 0 && a.retainedPayloadChunks.Load() >= a.maxRetainedPayloadChunks {
-		a.abortProtocolViolation("association retained payload chunk limit exceeded")
-		return false
-	}
 	stream := a.getOrCreateStream(chunkPayload.streamIdentifier, true, PayloadTypeUnknown)
 	if stream == nil {
 		// silently discard the data. (sender will retry on T3-rtx timeout)
 		// see pion/sctp#30
 		a.log.Debugf("[%s] discard %d", a.name, chunkPayload.streamSequenceNumber)
 
+		return false
+	}
+	if stream.isDuplicate(chunkPayload) {
+		return true
+	}
+	if a.maxRetainedPayloadChunks > 0 && a.retainedPayloadChunks.Load() >= a.maxRetainedPayloadChunks {
+		a.abortProtocolViolation("association retained payload chunk limit exceeded")
 		return false
 	}
 
@@ -2371,14 +2374,17 @@ func (a *Association) acceptPayloadData(chunkPayload *chunkPayloadData) bool {
 
 // The caller should hold the lock.
 func (a *Association) pushPayloadDataToStream(stream *Stream, chunkPayload *chunkPayloadData) bool {
-	a.retainedPayloadChunks.Add(1)
-	a.payloadQueue.push(chunkPayload.tsn)
-	if err := stream.handleData(chunkPayload); err != nil {
-		a.retainedPayloadChunks.Add(^uint32(0))
+	accepted, err := stream.handleData(chunkPayload)
+	if err != nil {
 		a.abortProtocolViolation(err.Error())
 
 		return false
 	}
+	if !accepted {
+		return true
+	}
+	a.retainedPayloadChunks.Add(1)
+	a.payloadQueue.push(chunkPayload.tsn)
 
 	return true
 }

--- a/association.go
+++ b/association.go
@@ -1239,7 +1239,6 @@ func (a *Association) unregisterStream(s *Stream, err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	s.reassemblyQueue.releaseAll()
 	delete(a.streams, s.streamIdentifier)
 	s.readErr = err
 	s.readNotifier.Broadcast()
@@ -3380,10 +3379,7 @@ func (a *Association) resetStreamsIfAny(resetRequest *paramOutgoingResetRequest)
 			s.onInboundStreamReset()
 			a.lock.Lock()
 			a.log.Debugf("[%s] deleting stream %d", a.name, id)
-			s.lock.Lock()
-			s.reassemblyQueue.releaseAll()
 			delete(a.streams, s.streamIdentifier)
-			s.lock.Unlock()
 		}
 		delete(a.reconfigRequests, resetRequest.reconfigRequestSequenceNumber)
 	} else {

--- a/association.go
+++ b/association.go
@@ -273,6 +273,9 @@ type Association struct {
 	maxReceiveBufferSize      uint32
 	maxMessageSize            uint32
 	maxReassemblyQueueEntries uint32
+	maxInboundMessageSize     uint32
+	maxRetainedPayloadChunks  uint32
+	retainedPayloadChunks     atomic.Uint32
 	cwnd                      uint32 // my congestion window size
 	rwnd                      uint32 // calculated peer's receiver windows size
 	ssthresh                  uint32 // slow start threshold
@@ -393,6 +396,10 @@ type Config struct {
 
 	// Reassembly queue config options
 	maxReassemblyQueueEntries uint32
+	maxInboundStreams         uint16
+	maxOutboundStreams        uint16
+	maxInboundMessageSize     uint32
+	maxRetainedPayloadChunks  uint32
 
 	// SNAP/sctp-init
 	snapConfig *snapConfig
@@ -762,12 +769,14 @@ func createAssociationFromConfigWithTsn(cfg *Config, tsn uint32) *Association {
 		maxReceiveBufferSize:      maxReceiveBufferSize,
 		maxMessageSize:            maxMessageSize,
 		maxReassemblyQueueEntries: cfg.maxReassemblyQueueEntries,
+		maxInboundMessageSize:     cfg.maxInboundMessageSize,
+		maxRetainedPayloadChunks:  cfg.maxRetainedPayloadChunks,
 		minCwnd:                   cfg.MinCwnd,
 		fastRtxWnd:                cfg.FastRtxWnd,
 		cwndCAStep:                cfg.CwndCAStep,
 
-		myMaxNumOutboundStreams: math.MaxUint16,
-		myMaxNumInboundStreams:  math.MaxUint16,
+		myMaxNumOutboundStreams: streamLimitOrMax(cfg.maxOutboundStreams),
+		myMaxNumInboundStreams:  streamLimitOrMax(cfg.maxInboundStreams),
 
 		payloadQueue:            newReceivePayloadQueue(getMaxTSNOffset(maxReceiveBufferSize)),
 		inflightQueue:           newPayloadQueue(),
@@ -841,6 +850,13 @@ func createAssociationFromConfigWithTsn(cfg *Config, tsn uint32) *Association {
 	assoc.ackTimer = newAckTimer(assoc)
 
 	return assoc
+}
+
+func streamLimitOrMax(limit uint16) uint16 {
+	if limit == 0 {
+		return math.MaxUint16
+	}
+	return limit
 }
 
 func (a *Association) initWithOutOfBandTokens(localInit *chunkInit, remoteInit *chunkInit) error {
@@ -1223,6 +1239,7 @@ func (a *Association) unregisterStream(s *Stream, err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	s.reassemblyQueue.releaseAll()
 	delete(a.streams, s.streamIdentifier)
 	s.readErr = err
 	s.readNotifier.Broadcast()
@@ -2312,6 +2329,14 @@ func (a *Association) handleData(chunkPayload *chunkPayloadData) []*packet {
 
 // The caller should hold the lock.
 func (a *Association) acceptPayloadData(chunkPayload *chunkPayloadData) bool {
+	if chunkPayload.streamIdentifier >= a.myMaxNumInboundStreams {
+		a.abortProtocolViolation("inbound stream limit exceeded")
+		return false
+	}
+	if a.maxRetainedPayloadChunks > 0 && a.retainedPayloadChunks.Load() >= a.maxRetainedPayloadChunks {
+		a.abortProtocolViolation("association retained payload chunk limit exceeded")
+		return false
+	}
 	stream := a.getOrCreateStream(chunkPayload.streamIdentifier, true, PayloadTypeUnknown)
 	if stream == nil {
 		// silently discard the data. (sender will retry on T3-rtx timeout)
@@ -2347,8 +2372,10 @@ func (a *Association) acceptPayloadData(chunkPayload *chunkPayloadData) bool {
 
 // The caller should hold the lock.
 func (a *Association) pushPayloadDataToStream(stream *Stream, chunkPayload *chunkPayloadData) bool {
+	a.retainedPayloadChunks.Add(1)
 	a.payloadQueue.push(chunkPayload.tsn)
 	if err := stream.handleData(chunkPayload); err != nil {
+		a.retainedPayloadChunks.Add(^uint32(0))
 		a.abortProtocolViolation(err.Error())
 
 		return false
@@ -2436,6 +2463,9 @@ func (a *Association) OpenStream(
 	case shutdownAckSent, shutdownPending, shutdownReceived, shutdownSent, closed:
 		return nil, ErrAssociationClosed
 	}
+	if streamIdentifier >= a.myMaxNumOutboundStreams {
+		return nil, ErrOutboundStreamLimitExceeded
+	}
 
 	return a.getOrCreateStream(streamIdentifier, false, defaultPayloadType), nil
 }
@@ -2462,6 +2492,12 @@ func (a *Association) createStream(streamIdentifier uint16, accept bool) *Stream
 		log:           a.log,
 		name:          fmt.Sprintf("%d:%s", streamIdentifier, a.name),
 		writeDeadline: deadline.New(),
+	}
+	stream.reassemblyQueue.maxMessageBytes = a.maxInboundMessageSize
+	stream.reassemblyQueue.onRelease = func(n uint32) {
+		for range n {
+			a.retainedPayloadChunks.Add(^uint32(0))
+		}
 	}
 
 	stream.readNotifier = sync.NewCond(&stream.lock)
@@ -3344,7 +3380,10 @@ func (a *Association) resetStreamsIfAny(resetRequest *paramOutgoingResetRequest)
 			s.onInboundStreamReset()
 			a.lock.Lock()
 			a.log.Debugf("[%s] deleting stream %d", a.name, id)
+			s.lock.Lock()
+			s.reassemblyQueue.releaseAll()
 			delete(a.streams, s.streamIdentifier)
+			s.lock.Unlock()
 		}
 		delete(a.reconfigRequests, resetRequest.reconfigRequestSequenceNumber)
 	} else {

--- a/association_options.go
+++ b/association_options.go
@@ -146,6 +146,18 @@ func WithMaxReassemblyQueueEntries(maxEntries uint32) AssociationOption {
 	})
 }
 
+func WithStreamLimits(inbound, outbound uint16) AssociationOption {
+	return sharedOption(func(c *Config) error { c.maxInboundStreams, c.maxOutboundStreams = inbound, outbound; return nil })
+}
+
+func WithMaxInboundMessageSize(size uint32) AssociationOption {
+	return sharedOption(func(c *Config) error { c.maxInboundMessageSize = size; return nil })
+}
+
+func WithMaxRetainedPayloadChunks(chunks uint32) AssociationOption {
+	return sharedOption(func(c *Config) error { c.maxRetainedPayloadChunks = chunks; return nil })
+}
+
 // WithRTOMax sets the max retransmission timeout in ms for the association.
 func WithRTOMax(rtoMax float64) AssociationOption {
 	return sharedOption(func(c *Config) error {

--- a/association_options_test.go
+++ b/association_options_test.go
@@ -11,7 +11,19 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestResourceLimitOptions(t *testing.T) {
+	cfg := &Config{}
+	require.NoError(t, WithStreamLimits(2, 3).applyClient(cfg))
+	require.Equal(t, uint16(2), cfg.maxInboundStreams)
+	require.Equal(t, uint16(3), cfg.maxOutboundStreams)
+	require.NoError(t, WithMaxInboundMessageSize(16).applyClient(cfg))
+	require.Equal(t, uint32(16), cfg.maxInboundMessageSize)
+	require.NoError(t, WithMaxRetainedPayloadChunks(8).applyClient(cfg))
+	require.Equal(t, uint32(8), cfg.maxRetainedPayloadChunks)
+}
 
 func udpPiper(t *testing.T) (net.Conn, net.Conn) {
 	t.Helper()

--- a/association_resource_limits_test.go
+++ b/association_resource_limits_test.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package sctp
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newResourceLimitTestAssociation(t *testing.T, opts ...AssociationOption) *Association {
+	t.Helper()
+	c1, c2 := net.Pipe()
+	a := createTestAssociationWithOptions(t, Config{NetConn: c1}, opts...)
+	t.Cleanup(func() { require.NoError(t, a.close()); require.NoError(t, c2.Close()) })
+	a.setState(established)
+	a.payloadQueue.init(0)
+	return a
+}
+
+func TestAssociationRetainedChunkLimitAndDuplicate(t *testing.T) {
+	a := newResourceLimitTestAssociation(t, WithMaxRetainedPayloadChunks(1024))
+	for tsn := uint32(1); tsn <= 1024; tsn++ {
+		a.handleData(&chunkPayloadData{tsn: tsn, streamIdentifier: 0, streamSequenceNumber: uint16(tsn), userData: []byte{1}})
+	}
+	require.Equal(t, uint32(1024), a.retainedPayloadChunks.Load())
+	require.False(t, a.willSendAbort)
+
+	a.handleData(&chunkPayloadData{tsn: 1024, streamIdentifier: 0, streamSequenceNumber: 1024, userData: []byte{9}})
+	require.Equal(t, uint32(1024), a.retainedPayloadChunks.Load())
+	require.False(t, a.willSendAbort)
+
+	a.handleData(&chunkPayloadData{tsn: 1025, streamIdentifier: 0, streamSequenceNumber: 1025, userData: []byte{1}})
+	require.True(t, a.willSendAbort)
+	cause, ok := a.willSendAbortCause.(*errorCauseProtocolViolation)
+	require.True(t, ok)
+	require.Equal(t, "association retained payload chunk limit exceeded", string(cause.additionalInformation))
+}
+
+func TestAssociationInboundMessageLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		interleaved bool
+	}{{"DATA", false}, {"I-DATA", true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newResourceLimitTestAssociation(t, WithMaxInboundMessageSize(16*1024))
+			a.useInterleaving = tc.interleaved
+			first := &chunkPayloadData{tsn: 1, streamIdentifier: 0, beginningFragment: true, userData: make([]byte, 16*1024)}
+			if tc.interleaved {
+				first.iData = true
+				first.messageIdentifier = 7
+			}
+			a.handleData(first)
+			require.False(t, a.willSendAbort)
+			next := &chunkPayloadData{tsn: 2, streamIdentifier: 0, endingFragment: true, userData: []byte{1}}
+			if tc.interleaved {
+				next.iData = true
+				next.messageIdentifier = 7
+				next.fragmentSequenceNumber = 1
+			}
+			a.handleData(next)
+			require.True(t, a.willSendAbort)
+			cause := a.willSendAbortCause.(*errorCauseProtocolViolation)
+			require.Equal(t, errInboundMessageLimitExceeded.Error(), string(cause.additionalInformation))
+		})
+	}
+}
+
+func TestAssociationStreamLimits(t *testing.T) {
+	a := newResourceLimitTestAssociation(t, WithStreamLimits(2, 2))
+	a.handleData(&chunkPayloadData{tsn: 1, streamIdentifier: 2, beginningFragment: true, endingFragment: true})
+	require.NotContains(t, a.streams, uint16(2))
+	require.True(t, a.willSendAbort)
+
+	b := newResourceLimitTestAssociation(t, WithStreamLimits(2, 2))
+	_, err := b.OpenStream(1, PayloadTypeWebRTCBinary)
+	require.NoError(t, err)
+	_, err = b.OpenStream(2, PayloadTypeWebRTCBinary)
+	require.ErrorIs(t, err, ErrOutboundStreamLimitExceeded)
+}
+
+func TestAssociationRetainedChargesReleaseOnReadAndForwardTSN(t *testing.T) {
+	a := newResourceLimitTestAssociation(t, WithMaxRetainedPayloadChunks(2))
+	a.handleData(&chunkPayloadData{tsn: 1, streamIdentifier: 0, streamSequenceNumber: 0, beginningFragment: true, endingFragment: true, userData: []byte("ok")})
+	require.Equal(t, uint32(1), a.retainedPayloadChunks.Load(), "complete unread message remains charged")
+	s := a.streams[0]
+	buf := make([]byte, 2)
+	_, _, err := s.ReadSCTP(buf)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), a.retainedPayloadChunks.Load())
+
+	a.handleData(&chunkPayloadData{tsn: 2, streamIdentifier: 0, streamSequenceNumber: 1, beginningFragment: true, userData: []byte("x")})
+	require.Equal(t, uint32(1), a.retainedPayloadChunks.Load())
+	s.handleForwardTSNForOrdered(1)
+	require.Equal(t, uint32(0), a.retainedPayloadChunks.Load())
+}
+
+func TestResourceLimitOptionsApplyClientAndServer(t *testing.T) {
+	opts := []AssociationOption{WithStreamLimits(2, 3), WithMaxInboundMessageSize(16), WithMaxRetainedPayloadChunks(8)}
+	for _, server := range []bool{false, true} {
+		cfg := &Config{}
+		for _, opt := range opts {
+			if server {
+				require.NoError(t, opt.applyServer(cfg))
+			} else {
+				require.NoError(t, opt.applyClient(cfg))
+			}
+		}
+		require.Equal(t, uint16(2), cfg.maxInboundStreams)
+		require.Equal(t, uint16(3), cfg.maxOutboundStreams)
+		require.Equal(t, uint32(16), cfg.maxInboundMessageSize)
+		require.Equal(t, uint32(8), cfg.maxRetainedPayloadChunks)
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -8,8 +8,10 @@ import (
 )
 
 var (
-	errNilNetConn       = errors.New("netConn must not be nil")
-	errNilLoggerFactory = errors.New("loggerFactory must not be nil")
+	errNilNetConn                  = errors.New("netConn must not be nil")
+	errNilLoggerFactory            = errors.New("loggerFactory must not be nil")
+	ErrOutboundStreamLimitExceeded = errors.New("outbound stream limit exceeded")
+	errInboundMessageLimitExceeded = errors.New("inbound message reassembly limit exceeded")
 
 	// errZeroMTUOption indicates that the MTU option was set to zero.
 	errZeroMTUOption = errors.New("MTU option cannot be set to zero")

--- a/reassembly_queue.go
+++ b/reassembly_queue.go
@@ -283,6 +283,9 @@ func (r *reassemblyQueue) push(chunk *chunkPayloadData) bool {
 }
 
 func (r *reassemblyQueue) pushWithError(chunk *chunkPayloadData) (bool, error) { //nolint:cyclop
+	if r.isDuplicate(chunk) {
+		return false, nil
+	}
 	if r.maxMessageBytes > 0 && uint64(r.queuedMessageBytes(chunk))+uint64(len(chunk.userData)) > uint64(r.maxMessageBytes) {
 		return false, errInboundMessageLimitExceeded
 	}
@@ -365,6 +368,36 @@ func (r *reassemblyQueue) pushWithError(chunk *chunkPayloadData) (bool, error) {
 	atomic.AddUint64(&r.nBytes, uint64(len(chunk.userData)))
 
 	return cset.pushNoDuplicate(chunk), nil
+}
+
+func (r *reassemblyQueue) isDuplicate(chunk *chunkPayloadData) bool {
+	if chunk.isIData() {
+		sets := []*chunkSetMID{r.orderedMIDMap[chunk.messageIdentifier], r.unorderedMIDMap[chunk.messageIdentifier]}
+		for _, set := range sets {
+			if set == nil {
+				continue
+			}
+			for _, c := range set.chunks {
+				if c.fragmentSequenceNumber == chunk.fragmentSequenceNumber {
+					return true
+				}
+			}
+		}
+		return r.hasQueuedUnorderedMID(chunk.messageIdentifier)
+	}
+	for _, sets := range [][]*chunkSet{r.ordered, r.unordered} {
+		for _, set := range sets {
+			if set.ssn == chunk.streamSequenceNumber && set.hasTSN(chunk.tsn) {
+				return true
+			}
+		}
+	}
+	for _, c := range r.unorderedChunks {
+		if c.tsn == chunk.tsn {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *reassemblyQueue) queuedMessageBytes(chunk *chunkPayloadData) int {

--- a/reassembly_queue.go
+++ b/reassembly_queue.go
@@ -771,50 +771,6 @@ func (r *reassemblyQueue) release(n uint32) {
 	}
 }
 
-func (r *reassemblyQueue) releaseAll() {
-	seen := map[uint32]struct{}{}
-	visit := func(c *chunkPayloadData) { seen[c.tsn] = struct{}{} }
-	for _, set := range r.ordered {
-		for _, c := range set.chunks {
-			visit(c)
-		}
-	}
-	for _, set := range r.unordered {
-		for _, c := range set.chunks {
-			visit(c)
-		}
-	}
-	for _, c := range r.unorderedChunks {
-		visit(c)
-	}
-	for _, set := range r.orderedMID {
-		for _, c := range set.chunks {
-			visit(c)
-		}
-	}
-	for _, set := range r.unorderedMID {
-		for _, c := range set.chunks {
-			visit(c)
-		}
-	}
-	for _, set := range r.orderedMIDMap {
-		for _, c := range set.chunks {
-			visit(c)
-		}
-	}
-	for _, set := range r.unorderedMIDMap {
-		for _, c := range set.chunks {
-			visit(c)
-		}
-	}
-	r.release(uint32(len(seen)))
-	r.ordered, r.unordered, r.unorderedChunks = nil, nil, nil
-	r.orderedMID, r.unorderedMID = nil, nil
-	r.orderedMIDMap = map[uint32]*chunkSetMID{}
-	r.unorderedMIDMap = map[uint32]*chunkSetMID{}
-	atomic.StoreUint64(&r.nBytes, 0)
-}
-
 func (r *reassemblyQueue) subtractNumBytes(nBytes int) {
 	cur := atomic.LoadUint64(&r.nBytes)
 	if int(cur) >= nBytes { //nolint:gosec // G115

--- a/reassembly_queue.go
+++ b/reassembly_queue.go
@@ -210,6 +210,8 @@ type reassemblyQueue struct {
 	useInterleaving bool
 	nBytes          uint64
 	maxEntries      uint32
+	maxMessageBytes uint32
+	onRelease       func(uint32)
 }
 
 var (
@@ -281,6 +283,9 @@ func (r *reassemblyQueue) push(chunk *chunkPayloadData) bool {
 }
 
 func (r *reassemblyQueue) pushWithError(chunk *chunkPayloadData) (bool, error) { //nolint:cyclop
+	if r.maxMessageBytes > 0 && uint64(r.queuedMessageBytes(chunk))+uint64(len(chunk.userData)) > uint64(r.maxMessageBytes) {
+		return false, errInboundMessageLimitExceeded
+	}
 	var cset *chunkSet
 
 	if chunk.isIData() {
@@ -360,6 +365,41 @@ func (r *reassemblyQueue) pushWithError(chunk *chunkPayloadData) (bool, error) {
 	atomic.AddUint64(&r.nBytes, uint64(len(chunk.userData)))
 
 	return cset.pushNoDuplicate(chunk), nil
+}
+
+func (r *reassemblyQueue) queuedMessageBytes(chunk *chunkPayloadData) int {
+	total := 0
+	visit := func(c *chunkPayloadData) {
+		if c.tsn != chunk.tsn && c.isIData() == chunk.isIData() &&
+			((chunk.isIData() && c.messageIdentifier == chunk.messageIdentifier) ||
+				(!chunk.isIData() && c.streamSequenceNumber == chunk.streamSequenceNumber)) {
+			total += len(c.userData)
+		}
+	}
+	for _, set := range r.ordered {
+		for _, c := range set.chunks {
+			visit(c)
+		}
+	}
+	for _, set := range r.unordered {
+		for _, c := range set.chunks {
+			visit(c)
+		}
+	}
+	for _, c := range r.unorderedChunks {
+		visit(c)
+	}
+	for _, set := range r.orderedMIDMap {
+		for _, c := range set.chunks {
+			visit(c)
+		}
+	}
+	for _, set := range r.unorderedMIDMap {
+		for _, c := range set.chunks {
+			visit(c)
+		}
+	}
+	return total
 }
 
 func (r *reassemblyQueue) pushIData(chunk *chunkPayloadData) (bool, error) {
@@ -593,6 +633,7 @@ func (r *reassemblyQueue) read(buf []byte) (int, PayloadProtocolIdentifier, erro
 		}
 
 		r.subtractNumBytes(nTotal)
+		r.release(uint32(len(iSet.chunks)))
 
 		return nTotal, iSet.ppi, err
 	}
@@ -636,6 +677,7 @@ func (r *reassemblyQueue) read(buf []byte) (int, PayloadProtocolIdentifier, erro
 	}
 
 	r.subtractNumBytes(nTotal)
+	r.release(uint32(len(cset.chunks)))
 
 	return nTotal, cset.ppi, err
 }
@@ -651,6 +693,7 @@ func (r *reassemblyQueue) forwardTSNForOrdered(lastSSN uint16) {
 				for _, c := range set.chunks {
 					r.subtractNumBytes(len(c.userData))
 				}
+				r.release(uint32(len(set.chunks)))
 
 				continue
 			}
@@ -682,6 +725,7 @@ func (r *reassemblyQueue) forwardTSNForUnordered(newCumulativeTSN uint32) {
 		for _, c := range r.unorderedChunks[0 : lastIdx+1] {
 			r.subtractNumBytes(len(c.userData))
 		}
+		r.release(uint32(lastIdx + 1))
 		r.unorderedChunks = r.unorderedChunks[lastIdx+1:]
 	}
 }
@@ -694,6 +738,7 @@ func (r *reassemblyQueue) forwardTSNForOrderedMID(lastMID uint32) {
 				for _, c := range set.chunks {
 					r.subtractNumBytes(len(c.userData))
 				}
+				r.release(uint32(len(set.chunks)))
 				delete(r.orderedMIDMap, set.mid)
 
 				continue
@@ -714,9 +759,60 @@ func (r *reassemblyQueue) forwardTSNForUnorderedMID(lastMID uint32) {
 			for _, c := range set.chunks {
 				r.subtractNumBytes(len(c.userData))
 			}
+			r.release(uint32(len(set.chunks)))
 			delete(r.unorderedMIDMap, mid)
 		}
 	}
+}
+
+func (r *reassemblyQueue) release(n uint32) {
+	if r.onRelease != nil && n > 0 {
+		r.onRelease(n)
+	}
+}
+
+func (r *reassemblyQueue) releaseAll() {
+	seen := map[uint32]struct{}{}
+	visit := func(c *chunkPayloadData) { seen[c.tsn] = struct{}{} }
+	for _, set := range r.ordered {
+		for _, c := range set.chunks {
+			visit(c)
+		}
+	}
+	for _, set := range r.unordered {
+		for _, c := range set.chunks {
+			visit(c)
+		}
+	}
+	for _, c := range r.unorderedChunks {
+		visit(c)
+	}
+	for _, set := range r.orderedMID {
+		for _, c := range set.chunks {
+			visit(c)
+		}
+	}
+	for _, set := range r.unorderedMID {
+		for _, c := range set.chunks {
+			visit(c)
+		}
+	}
+	for _, set := range r.orderedMIDMap {
+		for _, c := range set.chunks {
+			visit(c)
+		}
+	}
+	for _, set := range r.unorderedMIDMap {
+		for _, c := range set.chunks {
+			visit(c)
+		}
+	}
+	r.release(uint32(len(seen)))
+	r.ordered, r.unordered, r.unorderedChunks = nil, nil, nil
+	r.orderedMID, r.unorderedMID = nil, nil
+	r.orderedMIDMap = map[uint32]*chunkSetMID{}
+	r.unorderedMIDMap = map[uint32]*chunkSetMID{}
+	atomic.StoreUint64(&r.nBytes, 0)
 }
 
 func (r *reassemblyQueue) subtractNumBytes(nBytes int) {

--- a/reassembly_queue_test.go
+++ b/reassembly_queue_test.go
@@ -8,7 +8,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestReassemblyQueueMessageByteLimit(t *testing.T) {
+	r := newReassemblyQueue(1, 0)
+	r.maxMessageBytes = 4
+	first := &chunkPayloadData{streamIdentifier: 1, tsn: 1, beginningFragment: true, userData: []byte("1234")}
+	_, err := r.pushWithError(first)
+	require.NoError(t, err)
+	duplicate := *first
+	_, err = r.pushWithError(&duplicate)
+	require.NoError(t, err)
+	_, err = r.pushWithError(&chunkPayloadData{streamIdentifier: 1, tsn: 2, endingFragment: true, userData: []byte("5")})
+	require.ErrorIs(t, err, errInboundMessageLimitExceeded)
+}
 
 func TestReassemblyQueue(t *testing.T) { //nolint:maintidx,cyclop
 	t.Run("ordered fragments", func(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -200,14 +200,17 @@ func (s *Stream) SetReadDeadline(deadline time.Time) error {
 	return nil
 }
 
-func (s *Stream) handleData(pd *chunkPayloadData) error {
+func (s *Stream) handleData(pd *chunkPayloadData) (bool, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	if s.reassemblyQueue.isDuplicate(pd) {
+		return false, nil
+	}
 
 	var readable bool
 	complete, err := s.reassemblyQueue.pushWithError(pd)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if complete {
 		readable = s.reassemblyQueue.isReadable()
@@ -219,7 +222,13 @@ func (s *Stream) handleData(pd *chunkPayloadData) error {
 		}
 	}
 
-	return nil
+	return true, nil
+}
+
+func (s *Stream) isDuplicate(pd *chunkPayloadData) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.reassemblyQueue.isDuplicate(pd)
 }
 
 func (s *Stream) handleForwardTSNForOrdered(ssn uint16) {


### PR DESCRIPTION
Adds configurable negotiated inbound/outbound stream ceilings, an inbound per-message reassembly byte limit, and an association-wide retained payload-chunk limit. Admission is duplicate-safe, limits abort before retaining excess data, and charges return when payload becomes unreachable. Tests cover exact limits, limit-plus-one failures, DATA/I-DATA, duplicate-at-cap behavior, complete-unread accounting, read/Forward-TSN release, stream preallocation, client/server options, full suite, and focused race proof.