### PR TITLE
Set default MTU size to 1191

### DIFF
--- a/association.go
+++ b/association.go
@@ -70,13 +70,43 @@ var (
 
 const (
 	receiveMTU            uint32 = 8192 // MTU for inbound packet (from DTLS)
-	initialMTU            uint32 = 1228 // initial MTU for outgoing packets (to DTLS)
+	initialMTU            uint32 = 1191 // initial MTU for outgoing packets (to DTLS)
 	initialRecvBufSize    uint32 = 1024 * 1024
-	commonHeaderSize      uint32 = 12
-	dataChunkHeaderSize   uint32 = 16
-	iDataChunkHeaderSize  uint32 = 20
+	commonHeaderSize      uint32 = packetHeaderSize
+	dataChunkHeaderSize   uint32 = chunkHeaderSize + payloadDataHeaderSize
+	iDataChunkHeaderSize  uint32 = chunkHeaderSize + iDataHeaderSize
 	defaultMaxMessageSize uint32 = 65536
 )
+
+func payloadDataChunkHeaderSize(useInterleaving bool) uint32 {
+	if useInterleaving {
+		return iDataChunkHeaderSize
+	}
+
+	return dataChunkHeaderSize
+}
+
+func maxPayloadSizeForMTU(mtu uint32, useInterleaving bool) uint32 {
+	headerSize := commonHeaderSize + payloadDataChunkHeaderSize(useInterleaving)
+	if mtu <= headerSize {
+		return 0
+	}
+
+	payloadSize := mtu - headerSize
+
+	return payloadSize - payloadSize%paddingMultiple
+}
+
+func validateMTU(mtu uint32) error {
+	if mtu == 0 {
+		return errZeroMTUOption
+	}
+	if maxPayloadSizeForMTU(mtu, true) == 0 {
+		return errMTUTooSmallOption
+	}
+
+	return nil
+}
 
 // PartialReliabilityMode indicates the negotiated partial reliability mode.
 type PartialReliabilityMode int
@@ -554,6 +584,9 @@ func (c Config) applyServer(cfg *Config) error { //nolint:dupl,cyclop
 	cfg.EnableZeroChecksum = c.EnableZeroChecksum
 
 	if c.MTU != 0 {
+		if err := validateMTU(c.MTU); err != nil {
+			return err
+		}
 		cfg.MTU = c.MTU
 	}
 	if c.MaxReceiveBufferSize != 0 {
@@ -670,6 +703,9 @@ func (c Config) applyClient(cfg *Config) error { //nolint:dupl,cyclop
 	cfg.EnableZeroChecksum = c.EnableZeroChecksum
 
 	if c.MTU != 0 {
+		if err := validateMTU(c.MTU); err != nil {
+			return err
+		}
 		cfg.MTU = c.MTU
 	}
 	if c.MaxReceiveBufferSize != 0 {
@@ -729,6 +765,12 @@ func buildClientConfig(opts ...ClientOption) (*Config, error) {
 }
 
 func createAssociationFromConfig(cfg *Config) (*Association, error) {
+	if cfg.MTU != 0 {
+		if err := validateMTU(cfg.MTU); err != nil {
+			return nil, err
+		}
+	}
+
 	tsn := globalMathRandomGenerator.Uint32()
 
 	return createAssociationFromConfigWithTsn(cfg, tsn), nil
@@ -774,7 +816,7 @@ func createAssociationFromConfigWithTsn(cfg *Config, tsn uint32) *Association {
 		pendingQueue:            newPendingQueue(interleaving.newStreamScheduler),
 		controlQueue:            newControlQueue(),
 		mtu:                     mtu,
-		maxPayloadSize:          mtu - (commonHeaderSize + dataChunkHeaderSize),
+		maxPayloadSize:          maxPayloadSizeForMTU(mtu, false),
 		myVerificationTag:       generateInitiateTag(),
 		initialTSN:              tsn,
 		myNextTSN:               tsn,
@@ -1891,11 +1933,7 @@ func (a *Association) updateInterleavingState() error {
 		}
 
 		a.useInterleaving = useInterleaving
-		if useInterleaving {
-			a.maxPayloadSize = a.mtu - (commonHeaderSize + iDataChunkHeaderSize)
-		} else {
-			a.maxPayloadSize = a.mtu - (commonHeaderSize + dataChunkHeaderSize)
-		}
+		a.maxPayloadSize = maxPayloadSizeForMTU(a.mtu, useInterleaving)
 	}
 
 	if useInterleaving {

--- a/association_options.go
+++ b/association_options.go
@@ -96,11 +96,11 @@ func WithEnableInterleaving(b bool) AssociationOption {
 }
 
 // WithMTU sets the MTU size for the association.
-// By default this is 1228.
+// By default this is 1191.
 func WithMTU(size uint32) AssociationOption {
 	return sharedOption(func(c *Config) error {
-		if size == 0 {
-			return errZeroMTUOption
+		if err := validateMTU(size); err != nil {
+			return err
 		}
 		c.MTU = size
 

--- a/association_options_test.go
+++ b/association_options_test.go
@@ -60,6 +60,23 @@ func TestAssociationOptions_Interleaving(t *testing.T) {
 	assert.True(t, disabledCfg.enableInterleavingSet)
 }
 
+func TestAssociationOptions_DefaultMTU(t *testing.T) {
+	ca, cb := udpPiper(t)
+	defer func() {
+		_ = ca.Close()
+		_ = cb.Close()
+	}()
+
+	cfg, err := buildClientConfig(WithNetConn(ca))
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(1191), cfg.MTU)
+
+	assoc := createAssociationFromConfigWithTsn(cfg, 1)
+	defer assoc.close() //nolint:errcheck
+	assert.Equal(t, uint32(1191), assoc.MTU())
+	assert.Equal(t, maxPayloadSizeForMTU(initialMTU, false), assoc.maxPayloadSize)
+}
+
 func TestAssociationOptions_Validation(t *testing.T) {
 	t.Run("nil logger factory", func(t *testing.T) {
 		var cfg Config
@@ -77,6 +94,21 @@ func TestAssociationOptions_Validation(t *testing.T) {
 		var cfg Config
 		err := WithMTU(0).applyServer(&cfg)
 		assert.ErrorIs(t, err, errZeroMTUOption)
+	})
+
+	t.Run("mtu too small", func(t *testing.T) {
+		minMTU := commonHeaderSize + iDataChunkHeaderSize + paddingMultiple
+
+		var cfg Config
+		err := WithMTU(minMTU - 1).applyServer(&cfg)
+		assert.ErrorIs(t, err, errMTUTooSmallOption)
+
+		err = Config{MTU: minMTU - 1}.applyClient(&cfg)
+		assert.ErrorIs(t, err, errMTUTooSmallOption)
+
+		err = WithMTU(minMTU).applyServer(&cfg)
+		assert.NoError(t, err)
+		assert.Equal(t, minMTU, cfg.MTU)
 	})
 
 	t.Run("max recv buf zero", func(t *testing.T) {
@@ -213,8 +245,8 @@ func TestAssociationOptions_ClientAndServer(t *testing.T) {
 	assert.True(t, aClient.recvZeroChecksum)
 	assert.True(t, aServer.recvZeroChecksum)
 
-	assert.Equal(t, uint32(1200)-(commonHeaderSize+dataChunkHeaderSize), aClient.maxPayloadSize)
-	assert.Equal(t, uint32(1200)-(commonHeaderSize+dataChunkHeaderSize), aServer.maxPayloadSize)
+	assert.Equal(t, maxPayloadSizeForMTU(1200, false), aClient.maxPayloadSize)
+	assert.Equal(t, maxPayloadSizeForMTU(1200, false), aServer.maxPayloadSize)
 
 	assert.Equal(t, "opt-pair", aClient.name)
 	assert.Equal(t, "opt-pair", aServer.name)

--- a/association_test.go
+++ b/association_test.go
@@ -847,6 +847,23 @@ func TestAssociationInterleavingNegotiationPayloadChunkType(t *testing.T) {
 	}
 }
 
+func TestAssociationInterleavingUpdatesMaxPayloadSize(t *testing.T) {
+	assoc := createTestAssociation(t, Config{MTU: initialMTU})
+
+	require.False(t, assoc.useInterleaving)
+	require.Equal(t, maxPayloadSizeForMTU(initialMTU, false), assoc.maxPayloadSize)
+
+	assoc.peerInterleaving = true
+	require.NoError(t, assoc.updateInterleavingState())
+	require.True(t, assoc.useInterleaving)
+	require.Equal(t, maxPayloadSizeForMTU(initialMTU, true), assoc.maxPayloadSize)
+
+	assoc.peerInterleaving = false
+	require.NoError(t, assoc.updateInterleavingState())
+	require.False(t, assoc.useInterleaving)
+	require.Equal(t, maxPayloadSizeForMTU(initialMTU, false), assoc.maxPayloadSize)
+}
+
 func TestAssociationMetadataNotReadyBeforeHandshake(t *testing.T) {
 	assoc := createTestAssociation(t, Config{
 		NetConn: &dumbConn{},
@@ -5750,7 +5767,7 @@ func shutdownTLRAssociationForTest(a *Association, peer net.Conn) {
 func pushPendingFullPacketChunks(t *testing.T, a *Association, n int) {
 	t.Helper()
 
-	userLen := int(a.MTU()) - int(commonHeaderSize+dataChunkHeaderSize)
+	userLen := int(maxPayloadSizeForMTU(a.MTU(), false))
 	assert.True(t, userLen > 0)
 
 	for range n {
@@ -5766,7 +5783,7 @@ func pushPendingFullPacketChunks(t *testing.T, a *Association, n int) {
 func pushInflightRetransmitFullPacketChunks(t *testing.T, a *Association, startTSN uint32, n int) {
 	t.Helper()
 
-	userLen := int(a.MTU()) - int(commonHeaderSize+dataChunkHeaderSize)
+	userLen := int(maxPayloadSizeForMTU(a.MTU(), false))
 	assert.True(t, userLen > 0)
 
 	for i := range n {

--- a/chunk_i_data_test.go
+++ b/chunk_i_data_test.go
@@ -70,3 +70,63 @@ func TestChunkIDataMarshalUnmarshal(t *testing.T) {
 		assert.False(t, parsed.endingFragment)
 	})
 }
+
+func TestPayloadDataHeaderSizeAccounting(t *testing.T) {
+	t.Run("header constants match marshaled chunks", func(t *testing.T) {
+		data := &chunkPayloadData{
+			beginningFragment: true,
+			endingFragment:    true,
+		}
+		dataRaw, err := data.marshal()
+		assert.NoError(t, err)
+		assert.Equal(t, int(dataChunkHeaderSize), len(dataRaw))
+		assert.Equal(t, int(dataChunkHeaderSize), data.chunkSize())
+
+		iData := &chunkPayloadData{
+			iData:             true,
+			beginningFragment: true,
+			endingFragment:    true,
+		}
+		iDataRaw, err := iData.marshal()
+		assert.NoError(t, err)
+		assert.Equal(t, int(iDataChunkHeaderSize), len(iDataRaw))
+		assert.Equal(t, int(iDataChunkHeaderSize), iData.chunkSize())
+	})
+
+	t.Run("default MTU payload limits include padding", func(t *testing.T) {
+		testCases := []struct {
+			name            string
+			useInterleaving bool
+			expectedPayload uint32
+		}{
+			{
+				name:            "DATA",
+				useInterleaving: false,
+				expectedPayload: 1160,
+			},
+			{
+				name:            "I-DATA",
+				useInterleaving: true,
+				expectedPayload: 1156,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				payloadSize := maxPayloadSizeForMTU(initialMTU, tc.useInterleaving)
+				assert.Equal(t, tc.expectedPayload, payloadSize)
+
+				chunkPayload := &chunkPayloadData{
+					iData:             tc.useInterleaving,
+					beginningFragment: true,
+					endingFragment:    true,
+					userData:          make([]byte, payloadSize),
+				}
+				p := &packet{chunks: []chunk{chunkPayload}}
+				raw, err := p.marshal(false)
+				assert.NoError(t, err)
+				assert.LessOrEqual(t, len(raw), int(initialMTU))
+			})
+		}
+	})
+}

--- a/errors.go
+++ b/errors.go
@@ -14,6 +14,9 @@ var (
 	// errZeroMTUOption indicates that the MTU option was set to zero.
 	errZeroMTUOption = errors.New("MTU option cannot be set to zero")
 
+	// errMTUTooSmallOption indicates that the MTU cannot fit SCTP DATA and I-DATA headers plus padding.
+	errMTUTooSmallOption = errors.New("MTU option is too small")
+
 	// errZeroMaxReceiveBufferOption indicates that the MTU option was set to zero.
 	errZeroMaxReceiveBufferOption = errors.New("MaxReceiveBuffer option cannot be set to zero")
 


### PR DESCRIPTION
#### Description
some Raspberry PI connect users reported that pion/sctp can't send video over SCTP while Tailscale is enabled (Tailscale drops packets larger than 1280 bytes), with DTLS record header, cipher nonce, cipher auth tag, and IP header we can easily go over 1280 with 1228 as the default.

This sets the default MTU size to safer value[1] of 1191 instead of 1228 and account for chunk padding.

1. https://issues.webrtc.org/issues/42222640

I'll try to get PMTU implemented soon #12 