### PR TITLE
Set RACK test MTU to 512

### DIFF
--- a/vnet_test.go
+++ b/vnet_test.go
@@ -734,6 +734,10 @@ func TestRACK_RTTSwitch_Reordering_NoDrop(t *testing.T) { //nolint:gocyclo,cyclo
 	const (
 		numMessages = 40
 		messageSize = 256
+		// The VNet filter drops a whole SCTP packet, so keep exactly one
+		// message in each packet. Otherwise a single configured drop can
+		// legitimately cause several fast retransmits.
+		testMTU uint32 = 512
 	)
 
 	makeMessages := func() [][]byte {
@@ -781,6 +785,7 @@ func TestRACK_RTTSwitch_Reordering_NoDrop(t *testing.T) { //nolint:gocyclo,cyclo
 
 		assoc, err := Server(Config{
 			NetConn:       conn,
+			MTU:           testMTU,
 			LoggerFactory: loggerFactory,
 		})
 		if err != nil {
@@ -844,6 +849,7 @@ func TestRACK_RTTSwitch_Reordering_NoDrop(t *testing.T) { //nolint:gocyclo,cyclo
 
 		assoc, err := Client(Config{
 			NetConn:       conn,
+			MTU:           testMTU,
 			LoggerFactory: loggerFactory,
 		})
 		if err != nil {


### PR DESCRIPTION
#### Description
default test MTU that packet can contain four 256-byte i-data chunks, so fr=4 was valid.
The test now uses MTU 512 on both endpoints, to ensure one message per packet.
