### PR TITLE
Prevent partial sack processing

### DIFF
--- a/association.go
+++ b/association.go
@@ -2571,6 +2571,42 @@ func (a *Association) processSelectiveAck(selectiveAckChunk *chunkSelectiveAck) 
 	bytesAckedPerStream = map[uint16]int{}
 	now := time.Now() // capture the time for this SACK
 
+	// Validate that full range exists in the inflight queue to prevent partial pops
+	// left over from an invalid SACK that causes the cumulativeTSNAckPoint to be updated
+	// incorrectly and causes weird state and race conditions.
+	if sna32LT(a.cumulativeTSNAckPoint, selectiveAckChunk.cumulativeTSNAck) {
+		firstTSN := a.cumulativeTSNAckPoint + 1
+		if _, ok := a.inflightQueue.get(firstTSN); !ok {
+			return nil, 0, time.Time{}, 0, false, fmt.Errorf("%w: %v", ErrInflightQueueTSNPop, firstTSN)
+		}
+		if _, ok := a.inflightQueue.get(selectiveAckChunk.cumulativeTSNAck); !ok {
+			return nil, 0, time.Time{}, 0, false,
+				fmt.Errorf("%w: %v", ErrInflightQueueTSNPop, selectiveAckChunk.cumulativeTSNAck)
+		}
+	}
+	for _, gap := range selectiveAckChunk.gapAckBlocks {
+		if gap.start == 0 {
+			return nil, 0, time.Time{}, 0, false,
+				fmt.Errorf("%w: %v", ErrTSNRequestNotExist, selectiveAckChunk.cumulativeTSNAck)
+		}
+		if gap.start > gap.end {
+			return nil, 0, time.Time{}, 0, false,
+				fmt.Errorf("%w: invalid Gap Ack Block %d-%d", ErrTSNRequestNotExist, gap.start, gap.end)
+		}
+
+		firstTSN := selectiveAckChunk.cumulativeTSNAck + uint32(gap.start)
+		if _, ok := a.inflightQueue.get(firstTSN); !ok {
+			return nil, 0, time.Time{}, 0, false, fmt.Errorf("%w: %v", ErrTSNRequestNotExist, firstTSN)
+		}
+		lastTSN := selectiveAckChunk.cumulativeTSNAck + uint32(gap.end)
+		if lastTSN != firstTSN {
+			if _, ok := a.inflightQueue.get(lastTSN); !ok {
+				return nil, 0, time.Time{}, 0, false,
+					fmt.Errorf("%w: %v", ErrTSNRequestNotExist, lastTSN)
+			}
+		}
+	}
+
 	// New ack point, so pop all ACKed packets from inflightQueue
 	// We add 1 because the "currentAckPoint" has already been popped from the inflight queue
 	// For the first SACK we take care of this by setting the ackpoint to cumAck - 1

--- a/association_test.go
+++ b/association_test.go
@@ -5819,6 +5819,157 @@ func TestProcessSelectiveAck_GapBlockUint16Max(t *testing.T) {
 	assert.True(t, got.acked, "chunk should be marked as acked after SACK gap-block processing")
 }
 
+func TestProcessSelectiveAck_ValidationDoesNotMutateInflightQueue(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		inflightTSN []uint32
+		sack        chunkSelectiveAck
+		expectedErr error
+	}{
+		{
+			name:        "missing first cumulative TSN",
+			inflightTSN: []uint32{101},
+			sack:        chunkSelectiveAck{cumulativeTSNAck: 100},
+			expectedErr: ErrInflightQueueTSNPop,
+		},
+		{
+			name:        "missing last cumulative TSN",
+			inflightTSN: []uint32{100},
+			sack:        chunkSelectiveAck{cumulativeTSNAck: 101},
+			expectedErr: ErrInflightQueueTSNPop,
+		},
+		{
+			name:        "missing gap start",
+			inflightTSN: []uint32{100, 101},
+			sack: chunkSelectiveAck{
+				cumulativeTSNAck: 100,
+				gapAckBlocks:     []gapAckBlock{{start: 2, end: 2}},
+			},
+			expectedErr: ErrTSNRequestNotExist,
+		},
+		{
+			name:        "missing gap end",
+			inflightTSN: []uint32{100, 101},
+			sack: chunkSelectiveAck{
+				cumulativeTSNAck: 100,
+				gapAckBlocks:     []gapAckBlock{{start: 1, end: 2}},
+			},
+			expectedErr: ErrTSNRequestNotExist,
+		},
+		{
+			name:        "zero gap offset",
+			inflightTSN: []uint32{100, 101},
+			sack: chunkSelectiveAck{
+				cumulativeTSNAck: 100,
+				gapAckBlocks:     []gapAckBlock{{start: 0, end: 0}},
+			},
+			expectedErr: ErrTSNRequestNotExist,
+		},
+		{
+			name:        "reversed gap",
+			inflightTSN: []uint32{100, 101},
+			sack: chunkSelectiveAck{
+				cumulativeTSNAck: 99,
+				gapAckBlocks:     []gapAckBlock{{start: 2, end: 1}},
+			},
+			expectedErr: ErrTSNRequestNotExist,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assoc := newRackTestAssoc(t)
+			chunks := make([]*chunkPayloadData, 0, len(test.inflightTSN))
+			for _, tsn := range test.inflightTSN {
+				chunk := mkChunk(tsn, time.Now())
+				chunks = append(chunks, chunk)
+				assoc.inflightQueue.pushNoCheck(chunk)
+			}
+
+			assoc.lock.Lock()
+			_, _, _, _, _, err := assoc.processSelectiveAck(&test.sack) //nolint:dogsled
+			assoc.lock.Unlock()
+
+			if test.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, test.expectedErr)
+			}
+			for i, tsn := range test.inflightTSN {
+				got, ok := assoc.inflightQueue.get(tsn)
+				require.Truef(t, ok, "TSN %d was removed", tsn)
+				assert.Same(t, chunks[i], got)
+			}
+		})
+	}
+}
+
+func TestHandleSack_ReversedGapDoesNotPartiallyProcess(t *testing.T) {
+	assoc := newRackTestAssoc(t)
+	first := mkChunk(100, time.Now())
+	second := mkChunk(101, time.Now())
+	assoc.inflightQueue.pushNoCheck(first)
+	assoc.inflightQueue.pushNoCheck(second)
+
+	const initialRWND = 1234
+	assoc.setRWND(initialRWND)
+	assoc.inFastRecovery = true
+	assoc.fastRecoverExitPoint = 101
+	require.False(t, assoc.t3RTX.isRunning())
+	defer assoc.t3RTX.stop()
+
+	sack := &chunkSelectiveAck{
+		cumulativeTSNAck:               100,
+		advertisedReceiverWindowCredit: 4096,
+		gapAckBlocks:                   []gapAckBlock{{start: 4, end: 3}},
+	}
+
+	assoc.lock.Lock()
+	err := assoc.handleSack(sack)
+	assoc.lock.Unlock()
+
+	require.ErrorIs(t, err, ErrTSNRequestNotExist)
+	assert.Equal(t, uint32(99), assoc.cumulativeTSNAckPoint)
+	assert.Equal(t, uint32(initialRWND), assoc.RWND())
+	assert.Equal(t, 2, assoc.inflightQueue.size())
+	assert.Equal(t, 2, assoc.inflightQueue.getNumBytes())
+
+	got, ok := assoc.inflightQueue.get(100)
+	require.True(t, ok)
+	assert.Same(t, first, got)
+	assert.False(t, got.acked)
+	assert.False(t, got.retransmit)
+	assert.Zero(t, got.missIndicator)
+
+	got, ok = assoc.inflightQueue.get(101)
+	require.True(t, ok)
+	assert.Same(t, second, got)
+	assert.False(t, got.acked)
+	assert.False(t, got.retransmit)
+	assert.Zero(t, got.missIndicator)
+
+	assert.True(t, assoc.inFastRecovery)
+	assert.Equal(t, uint32(101), assoc.fastRecoverExitPoint)
+	assert.False(t, assoc.willRetransmitFast)
+	assert.False(t, assoc.t3RTX.isRunning())
+}
+
+func TestProcessSelectiveAck_CumulativeTSNWrap(t *testing.T) {
+	assoc := newRackTestAssoc(t)
+	assoc.cumulativeTSNAckPoint = math.MaxUint32 - 1
+
+	for _, tsn := range []uint32{math.MaxUint32, 0, 1} {
+		assoc.inflightQueue.pushNoCheck(mkChunk(tsn, time.Now()))
+	}
+
+	assoc.lock.Lock()
+	_, _, _, _, _, err := assoc.processSelectiveAck(&chunkSelectiveAck{ //nolint:dogsled
+		cumulativeTSNAck: 1,
+	})
+	assoc.lock.Unlock()
+
+	require.NoError(t, err)
+	assert.Zero(t, assoc.inflightQueue.size())
+}
+
 func TestRTOClearsFastRecovery(t *testing.T) {
 	assoc := newRackTestAssoc(t)
 

--- a/payload_queue.go
+++ b/payload_queue.go
@@ -35,12 +35,13 @@ func (q *payloadQueue) get(tsn uint32) (*chunkPayloadData, bool) {
 	if length == 0 {
 		return nil, false
 	}
-	head := q.chunks.Front().tsn
-	if tsn < head || int(tsn-head) >= length {
+
+	offset := tsn - q.chunks.Front().tsn
+	if int64(offset) >= int64(length) {
 		return nil, false
 	}
 
-	return q.chunks.At(int(tsn - head)), true
+	return q.chunks.At(int(offset)), true
 }
 
 func (q *payloadQueue) markAsAcked(tsn uint32) int {


### PR DESCRIPTION
#### Description
Validate that full range exists in the inflight queue to prevent partial pops
left over from an invalid SACK that causes the cumulativeTSNAckPoint to be updated 
incorrectly and causes weird state and race conditions.
#### Reference issue
I thought this was caused by a broken test when I saw it first in the CI but it happens a few times.

When a sack contained a gap referencing a missing tsn, we could:
1. Remove cumulatively acknowledged packets from the in-flight queue.
2. Or, encounter the missing TSN and return an error.
3, Or, fail to update the cumulative ACK point.

shutdown then waited forever for data to drain, causing the five-minute timeout and goroutine leaks.

> sctp ERROR: 2026/07/26 03:37:30 [0xc000208388] retransmission failure: T1-cookie
sctp ERROR: 2026/07/26 03:37:39 Failed to handle chunk: requested non-existent TSN: 3597224921
--- FAIL: TestAssociation_ShutdownDuringWrite (301.06s)
    association_test.go:4892: 
        	Error Trace:	/Users/runner/work/sctp/sctp/association_test.go:4892
        	Error:      	Received unexpected error:
        	            	context deadline exceeded
        	Test:       	TestAssociation_ShutdownDuringWrite
        	Messages:   	timed out waiting for a1 shutdown to complete
    association_test.go:3470: 
        	Error Trace:	/Users/runner/work/sctp/sctp/association_test.go:3470
        	            				/Users/runner/hostedtoolcache/go/1.24.13/arm64/src/testing/testing.go:1211
        	            				/Users/runner/hostedtoolcache/go/1.24.13/arm64/src/testing/testing.go:1445
        	            				/Users/runner/hostedtoolcache/go/1.24.13/arm64/src/testing/testing.go:1786
        	            				/Users/runner/hostedtoolcache/go/1.24.13/arm64/src/runtime/panic.go:636
        	            				/Users/runner/hostedtoolcache/go/1.24.13/arm64/src/testing/testing.go:1041
        	            				/Users/runner/work/sctp/sctp/association_test.go:4892
        	Error:      	goroutine leak
        	Test:       	TestAssociation_ShutdownDuringWrite
        	Messages:   	leaked: 6