### PR TITLE
Ack data in SHUDOWN-SENT

### DIFF
--- a/association.go
+++ b/association.go
@@ -1599,7 +1599,7 @@ func (a *Association) gatherOutboundShutdownPackets(rawPackets [][]byte) ([][]by
 		a.willSendShutdown = false
 
 		shutdown := &chunkShutdown{
-			cumulativeTSNAck: a.cumulativeTSNAckPoint,
+			cumulativeTSNAck: a.peerLastTSN(),
 		}
 
 		raw, err := a.marshalPacket(a.createPacket([]chunk{shutdown}))
@@ -2320,10 +2320,14 @@ func (a *Association) handleCookieAck() {
 	a.completeHandshake(nil)
 }
 
+func isDataReceiveState(state uint32) bool {
+	return state == established || state == shutdownPending || state == shutdownSent
+}
+
 // The caller should hold the lock.
 func (a *Association) handleData(chunkPayload *chunkPayloadData) []*packet {
 	state := a.getState()
-	if state != established && state != shutdownPending && state != shutdownReceived {
+	if !isDataReceiveState(state) {
 		return nil
 	}
 
@@ -2341,9 +2345,21 @@ func (a *Association) handleData(chunkPayload *chunkPayloadData) []*packet {
 		a.name, chunkPayload.tsn, chunkPayload.immediateSack, len(chunkPayload.userData))
 	a.stats.incDATAs()
 
+	if state == shutdownSent {
+		// RFC 9260 Sections 6 and 9.2 require DATA received in
+		// SHUTDOWN-SENT to be acknowledged without delay and answered with a
+		// SHUTDOWN. Restart T2 when that SHUTDOWN is sent.
+		a.willSendShutdown = true
+		a.t2Shutdown.stop()
+	}
+
 	canPush := a.payloadQueue.canPush(chunkPayload.tsn)
 	if canPush {
 		if !a.acceptPayloadData(chunkPayload) {
+			if state == shutdownSent {
+				return a.handlePeerLastTSNAndAcknowledgement(true)
+			}
+
 			return nil
 		}
 	}
@@ -2358,6 +2374,9 @@ func (a *Association) handleData(chunkPayload *chunkPayloadData) []*packet {
 	gapDetected := sna32GT(chunkPayload.tsn, expectedTSN)
 
 	sackNow := chunkPayload.immediateSack || gapDetected
+	if state == shutdownSent {
+		sackNow = true
+	}
 
 	return a.handlePeerLastTSNAndAcknowledgement(sackNow)
 }

--- a/association_test.go
+++ b/association_test.go
@@ -1004,6 +1004,53 @@ func TestAssociationDataIgnoredBeforeEstablished(t *testing.T) {
 	require.Zero(t, assoc.stats.getNumDATAs())
 }
 
+func TestAssociationDataAcknowledgedInShutdownSent(t *testing.T) {
+	assoc := createTestAssociation(t, Config{})
+	assoc.payloadQueue.init(0)
+	assoc.cumulativeTSNAckPoint = 100
+	assoc.setState(shutdownSent)
+	require.True(t, assoc.t2Shutdown.start(1000))
+	t.Cleanup(assoc.t2Shutdown.close)
+
+	packets := assoc.handleData(&chunkPayloadData{
+		beginningFragment: true,
+		endingFragment:    true,
+		tsn:               1,
+		streamIdentifier:  1,
+		payloadType:       PayloadTypeWebRTCBinary,
+		userData:          []byte("in flight during shutdown"),
+	})
+
+	require.Nil(t, packets)
+	assert.Equal(t, uint32(1), assoc.peerLastTSN())
+	assert.True(t, assoc.immediateAckTriggered)
+	assert.True(t, assoc.willSendShutdown)
+	assert.False(t, assoc.t2Shutdown.isRunning())
+
+	assoc.handleChunksEnd()
+	rawPackets, ok := assoc.gatherOutbound()
+	require.True(t, ok)
+	require.Len(t, rawPackets, 2)
+	assert.True(t, assoc.t2Shutdown.isRunning())
+
+	var sackFound, shutdownFound bool
+	for _, raw := range rawPackets {
+		packet := &packet{}
+		require.NoError(t, packet.unmarshal(false, raw))
+		require.Len(t, packet.chunks, 1)
+		switch c := packet.chunks[0].(type) {
+		case *chunkSelectiveAck:
+			sackFound = true
+			assert.Equal(t, uint32(1), c.cumulativeTSNAck)
+		case *chunkShutdown:
+			shutdownFound = true
+			assert.Equal(t, uint32(1), c.cumulativeTSNAck)
+		}
+	}
+	assert.True(t, sackFound)
+	assert.True(t, shutdownFound)
+}
+
 func TestAssociationInterleavingProtocolViolationWrongForwardTSNChunkType(t *testing.T) {
 	tests := []struct {
 		name                string


### PR DESCRIPTION
#### Description
A gap i found while fixing https://github.com/pion/sctp/pull/480 
accept and immediately acknowledge data while in SHUTDOWN-SENT, then send a SHUTDOWN response, and restart T2 to prevent shutdown deadlocks.