### PR TITLE
Handle graceful shutdown state transitions

### DIFF
--- a/association.go
+++ b/association.go
@@ -265,6 +265,7 @@ type Association struct {
 	willSendShutdown         bool
 	willSendShutdownAck      bool
 	willSendShutdownComplete bool
+	shutdownCompletePending  bool
 
 	willSendAbort      bool
 	willSendAbortCause errorCause
@@ -1004,24 +1005,27 @@ func (a *Association) sendCookieEcho() error {
 func (a *Association) Shutdown(ctx context.Context) error {
 	a.log.Debugf("[%s] closing association..", a.name)
 
+	a.lock.Lock()
+
 	state := a.getState()
 
 	if state != established {
+		a.lock.Unlock()
+
 		return fmt.Errorf("%w: shutdown %s", ErrShutdownNonEstablished, a.name)
 	}
 
 	// Attempt a graceful shutdown.
 	a.setState(shutdownPending)
+	a.unblockPendingWrites()
 
-	a.lock.Lock()
-
-	if a.inflightQueue.size() == 0 {
+	if !a.hasPendingOrInflightData() {
 		// No more outstanding, send shutdown.
 		a.willSendShutdown = true
-		a.awakeWriteLoop()
 		a.setState(shutdownSent)
 	}
 
+	a.awakeWriteLoop()
 	a.lock.Unlock()
 
 	select {
@@ -1352,6 +1356,27 @@ func (a *Association) gatherDataPacketsToRetransmit(rawPackets [][]byte, budgetU
 }
 
 // The caller should hold the lock.
+func (a *Association) gatherOutboundReconfigPackets(rawPackets [][]byte) [][]byte {
+	if !a.willRetransmitReconfig {
+		return rawPackets
+	}
+
+	a.willRetransmitReconfig = false
+	a.log.Debugf("[%s] retransmit %d RECONFIG chunk(s)", a.name, len(a.reconfigs))
+	for _, c := range a.reconfigs {
+		p := a.createPacket([]chunk{c})
+		raw, err := a.marshalPacket(p)
+		if err != nil {
+			a.log.Warnf("[%s] failed to serialize a RECONFIG packet to be retransmitted", a.name)
+		} else {
+			rawPackets = append(rawPackets, raw)
+		}
+	}
+
+	return rawPackets
+}
+
+// The caller should hold the lock.
 //
 //nolint:cyclop
 func (a *Association) gatherOutboundDataAndReconfigPackets(
@@ -1381,19 +1406,7 @@ func (a *Association) gatherOutboundDataAndReconfigPackets(
 	}
 
 	if len(sisToReset) > 0 || a.willRetransmitReconfig { //nolint:nestif
-		if a.willRetransmitReconfig {
-			a.willRetransmitReconfig = false
-			a.log.Debugf("[%s] retransmit %d RECONFIG chunk(s)", a.name, len(a.reconfigs))
-			for _, c := range a.reconfigs {
-				p := a.createPacket([]chunk{c})
-				raw, err := a.marshalPacket(p)
-				if err != nil {
-					a.log.Warnf("[%s] failed to serialize a RECONFIG packet to be retransmitted", a.name)
-				} else {
-					rawPackets = append(rawPackets, raw)
-				}
-			}
-		}
+		rawPackets = a.gatherOutboundReconfigPackets(rawPackets)
 
 		if len(sisToReset) > 0 {
 			rsn := a.generateNextRSN()
@@ -1595,6 +1608,33 @@ func (a *Association) gatherOutboundShutdownPackets(rawPackets [][]byte) ([][]by
 	ok := true
 
 	switch {
+	case a.willSendShutdownComplete:
+		a.willSendShutdownComplete = false
+		a.willSendShutdownAck = false
+		a.willSendShutdown = false
+
+		shutdownComplete := &chunkShutdownComplete{}
+
+		raw, err := a.marshalPacket(a.createPacket([]chunk{shutdownComplete}))
+		if err != nil {
+			a.log.Warnf("[%s] failed to serialize a ShutdownComplete packet", a.name)
+		} else {
+			rawPackets = append(rawPackets, raw)
+			ok = false
+		}
+	case a.willSendShutdownAck:
+		a.willSendShutdownAck = false
+		a.willSendShutdown = false
+
+		shutdownAck := &chunkShutdownAck{}
+
+		raw, err := a.marshalPacket(a.createPacket([]chunk{shutdownAck}))
+		if err != nil {
+			a.log.Warnf("[%s] failed to serialize a ShutdownAck packet", a.name)
+		} else {
+			a.t2Shutdown.start(a.rtoMgr.getRTO())
+			rawPackets = append(rawPackets, raw)
+		}
 	case a.willSendShutdown:
 		a.willSendShutdown = false
 
@@ -1608,30 +1648,6 @@ func (a *Association) gatherOutboundShutdownPackets(rawPackets [][]byte) ([][]by
 		} else {
 			a.t2Shutdown.start(a.rtoMgr.getRTO())
 			rawPackets = append(rawPackets, raw)
-		}
-	case a.willSendShutdownAck:
-		a.willSendShutdownAck = false
-
-		shutdownAck := &chunkShutdownAck{}
-
-		raw, err := a.marshalPacket(a.createPacket([]chunk{shutdownAck}))
-		if err != nil {
-			a.log.Warnf("[%s] failed to serialize a ShutdownAck packet", a.name)
-		} else {
-			a.t2Shutdown.start(a.rtoMgr.getRTO())
-			rawPackets = append(rawPackets, raw)
-		}
-	case a.willSendShutdownComplete:
-		a.willSendShutdownComplete = false
-
-		shutdownComplete := &chunkShutdownComplete{}
-
-		raw, err := a.marshalPacket(a.createPacket([]chunk{shutdownComplete}))
-		if err != nil {
-			a.log.Warnf("[%s] failed to serialize a ShutdownComplete packet", a.name)
-		} else {
-			rawPackets = append(rawPackets, raw)
-			ok = false
 		}
 	}
 
@@ -1655,12 +1671,9 @@ func (a *Association) gatherAbortPacket() ([]byte, error) {
 	return raw, err
 }
 
-// gatherOutbound gathers outgoing packets. The returned bool value set to
-// false means the association should be closed down after the final send.
-func (a *Association) gatherOutbound() ([][]byte, bool) {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-
+// The caller should hold the lock. The final bool reports whether the
+// returned packets terminate the association and suppress all other output.
+func (a *Association) gatherOutboundPriorityPackets() ([][]byte, bool, bool) {
 	if a.willSendAbort {
 		pkt, err := a.gatherAbortPacket()
 		if err != nil {
@@ -1670,13 +1683,51 @@ func (a *Association) gatherOutbound() ([][]byte, bool) {
 			// (even though it failed) to avoid unnecessary delays.
 			a.abortSentOnce.Do(func() { close(a.abortSentCh) })
 
-			return nil, false
+			return nil, false, true
 		}
 
-		return [][]byte{pkt}, false
+		return [][]byte{pkt}, false, true
 	}
 
-	rawPackets := [][]byte{}
+	// Once SHUTDOWN ACK has been received, SHUTDOWN COMPLETE is the only
+	// protocol response left to send. Do not let queued control or DATA
+	// traffic delay the terminal response.
+	if a.willSendShutdownComplete {
+		rawPackets, ok := a.gatherOutboundShutdownPackets(nil)
+
+		return rawPackets, ok, true
+	}
+
+	// A retransmitted or crossed SHUTDOWN must not sit behind unrelated
+	// control traffic while the peer is waiting for SHUTDOWN ACK.
+	if a.getState() == shutdownAckSent && a.willSendShutdownAck {
+		rawPackets, ok := a.gatherOutboundShutdownPackets(nil)
+
+		return rawPackets, ok, false
+	}
+
+	// DATA received after sending SHUTDOWN requires an immediate updated
+	// SHUTDOWN response, plus a SACK when gaps or duplicates require one.
+	if a.getState() == shutdownSent && a.willSendShutdown {
+		rawPackets := a.gatherOutboundSackPackets(nil)
+		rawPackets, ok := a.gatherOutboundShutdownPackets(rawPackets)
+
+		return rawPackets, ok, false
+	}
+
+	return nil, true, false
+}
+
+// gatherOutbound gathers outgoing packets. The returned bool value set to
+// false means the association should be closed down after the final send.
+func (a *Association) gatherOutbound() ([][]byte, bool) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	rawPackets, ok, terminal := a.gatherOutboundPriorityPackets()
+	if terminal {
+		return rawPackets, ok
+	}
 
 	if a.controlQueue.size() > 0 {
 		for _, p := range a.controlQueue.popAll() {
@@ -1692,8 +1743,6 @@ func (a *Association) gatherOutbound() ([][]byte, bool) {
 
 	state := a.getState()
 
-	ok := true
-
 	switch state {
 	case established:
 		budgetUnits := a.tlrCurrentBurstBudgetScaledLocked()
@@ -1706,17 +1755,25 @@ func (a *Association) gatherOutbound() ([][]byte, bool) {
 		// control traffic shouldn't be limited.
 		rawPackets = a.gatherOutboundSackPackets(rawPackets)
 		rawPackets = a.gatherOutboundForwardTSNPackets(rawPackets)
-	case shutdownPending, shutdownSent, shutdownReceived:
+	case shutdownPending, shutdownReceived:
 		budgetUnits := a.tlrCurrentBurstBudgetScaledLocked()
 		consumed := false
 
 		rawPackets = a.gatherDataPacketsToRetransmit(rawPackets, &budgetUnits, &consumed)
+		rawPackets = a.gatherOutboundDataAndReconfigPackets(rawPackets, &budgetUnits, &consumed)
 		rawPackets = a.gatherOutboundFastRetransmissionPackets(rawPackets, &budgetUnits, &consumed)
+		a.advanceShutdownAfterDataDrain(state)
 
 		rawPackets = a.gatherOutboundSackPackets(rawPackets)
+		rawPackets = a.gatherOutboundForwardTSNPackets(rawPackets)
 		rawPackets, ok = a.gatherOutboundShutdownPackets(rawPackets)
+	case shutdownSent:
+		rawPackets = a.gatherOutboundSackPackets(rawPackets)
+		rawPackets, ok = a.gatherOutboundShutdownPackets(rawPackets)
+		rawPackets = a.gatherOutboundReconfigPackets(rawPackets)
 	case shutdownAckSent:
 		rawPackets, ok = a.gatherOutboundShutdownPackets(rawPackets)
+		rawPackets = a.gatherOutboundReconfigPackets(rawPackets)
 	}
 
 	return rawPackets, ok
@@ -1977,11 +2034,33 @@ func (a *Association) abortProtocolViolation(reason string) {
 }
 
 // The caller should hold the lock.
+func (a *Association) retransmitShutdownAck() {
+	if a.shutdownCompletePending {
+		return
+	}
+
+	a.t2Shutdown.stop()
+	a.willSendShutdown = false
+	a.willSendShutdownAck = true
+	a.awakeWriteLoop()
+}
+
+// The caller should hold the lock.
 //
 //nolint:cyclop
 func (a *Association) handleInit(pkt *packet, initChunk *chunkInit) ([]*packet, error) {
 	state := a.getState()
 	a.log.Debugf("[%s] chunkInit received in state '%s'", a.name, getAssociationStateString(state))
+
+	if state == shutdownAckSent {
+		// RFC 9260 Section 9.2: only an INIT whose SCTP port pair belongs
+		// to this association triggers a retransmission of SHUTDOWN ACK.
+		if a.sourcePort == pkt.destinationPort && a.destinationPort == pkt.sourcePort {
+			a.retransmitShutdownAck()
+		}
+
+		return nil, nil
+	}
 
 	// https://tools.ietf.org/html/rfc4960#section-5.2.1
 	// Upon receipt of an INIT in the COOKIE-WAIT state, an endpoint MUST
@@ -2324,10 +2403,14 @@ func isDataReceiveState(state uint32) bool {
 	return state == established || state == shutdownPending || state == shutdownSent
 }
 
+func (a *Association) canHandleData(state uint32) bool {
+	return !a.shutdownCompletePending && isDataReceiveState(state)
+}
+
 // The caller should hold the lock.
 func (a *Association) handleData(chunkPayload *chunkPayloadData) []*packet {
 	state := a.getState()
-	if !isDataReceiveState(state) {
+	if !a.canHandleData(state) {
 		return nil
 	}
 
@@ -3074,21 +3157,44 @@ func (a *Association) postprocessSack(state uint32, shouldAwakeWriteLoop bool) {
 		// Start timer. (noop if already started)
 		a.log.Tracef("[%s] T3-rtx timer start (pt3)", a.name)
 		a.t3RTX.start(a.rtoMgr.getRTO())
-	case state == shutdownPending:
-		// No more outstanding, send shutdown.
+	case a.pendingQueue.size() > 0:
+		// The SACK opened room for DATA accepted before shutdown started.
 		shouldAwakeWriteLoop = true
-		a.willSendShutdown = true
-		a.setState(shutdownSent)
-	case state == shutdownReceived:
-		// No more outstanding, send shutdown ack.
-		shouldAwakeWriteLoop = true
-		a.willSendShutdownAck = true
-		a.setState(shutdownAckSent)
+	default:
+		// No more queued or outstanding DATA; advance shutdown if needed.
+		if a.advanceShutdownAfterDataDrain(state) {
+			shouldAwakeWriteLoop = true
+		}
 	}
 
 	if shouldAwakeWriteLoop {
 		a.awakeWriteLoop()
 	}
+}
+
+// The caller should hold the lock.
+func (a *Association) advanceShutdownAfterDataDrain(state uint32) bool {
+	if a.hasPendingOrInflightData() {
+		return false
+	}
+
+	switch state {
+	case shutdownPending:
+		a.willSendShutdown = true
+		a.setState(shutdownSent)
+	case shutdownReceived:
+		a.willSendShutdownAck = true
+		a.setState(shutdownAckSent)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// The caller should hold the lock.
+func (a *Association) hasPendingOrInflightData() bool {
+	return a.pendingQueue.size() > 0 || a.inflightQueue.size() > 0
 }
 
 // processShutdownAcknowledgement processes the Cumulative TSN Ack carried by
@@ -3119,10 +3225,50 @@ func (a *Association) processShutdownAcknowledgement(c *chunkShutdown) error {
 	return nil
 }
 
+func isShutdownHandleState(state uint32) bool {
+	switch state {
+	case established, shutdownPending, shutdownReceived, shutdownSent:
+		return true
+	default:
+		return false
+	}
+}
+
+func entersShutdownReceived(state uint32) bool {
+	return state == established || state == shutdownPending
+}
+
 // The caller should hold the lock.
-func (a *Association) handleShutdown(chunk *chunkShutdown) error {
+func (a *Association) finishShutdownHandling(state uint32) {
+	switch state {
+	case established, shutdownPending, shutdownReceived:
+		if a.hasPendingOrInflightData() {
+			a.setState(shutdownReceived)
+			if a.pendingQueue.size() > 0 {
+				a.awakeWriteLoop()
+			}
+		} else {
+			// No more queued or outstanding DATA, send shutdown ack.
+			a.willSendShutdownAck = true
+			a.setState(shutdownAckSent)
+
+			a.awakeWriteLoop()
+		}
+	}
+}
+
+// The caller should hold the lock.
+func (a *Association) handleShutdown(shutdown *chunkShutdown) error {
+	if a.shutdownCompletePending {
+		return nil
+	}
+
 	state := a.getState()
-	if state != established && state != shutdownReceived && state != shutdownSent {
+	if state == shutdownAckSent {
+		// Continue responding to retransmitted SHUTDOWN chunks after reaching
+		// SHUTDOWN-RECEIVED, as required by RFC 9260 Section 9.2.
+		a.retransmitShutdownAck()
+
 		return nil
 	}
 
@@ -3141,14 +3287,18 @@ func (a *Association) handleShutdown(chunk *chunkShutdown) error {
 		return nil
 	}
 
-	if state == established {
+	if !isShutdownHandleState(state) {
+		return nil
+	}
+
+	if entersShutdownReceived(state) {
 		// Reject new user DATA before acknowledgement processing can release
 		// a.lock and invoke a stream's OnBufferedAmountLow callback.
 		a.setState(shutdownReceived)
 	}
 
 	previousCumulativeTSNAckPoint := a.cumulativeTSNAckPoint
-	if err := a.processShutdownAcknowledgement(chunk); err != nil {
+	if err := a.processShutdownAcknowledgement(shutdown); err != nil {
 		// Invalid acknowledgement fields are rejected before the transmit
 		// acknowledgement point advances. Restore the pre-SHUTDOWN state so a
 		// malformed chunk cannot strand the association in SHUTDOWN-RECEIVED.
@@ -3159,18 +3309,10 @@ func (a *Association) handleShutdown(chunk *chunkShutdown) error {
 		return err
 	}
 
-	switch state {
-	case established, shutdownReceived:
-		if a.inflightQueue.size() > 0 {
-			a.setState(shutdownReceived)
-		} else {
-			// No more outstanding, send shutdown ack.
-			a.willSendShutdownAck = true
-			a.setState(shutdownAckSent)
-
-			a.awakeWriteLoop()
-		}
+	if entersShutdownReceived(state) {
+		a.unblockPendingWrites()
 	}
+	a.finishShutdownHandling(state)
 
 	return nil
 }
@@ -3180,6 +3322,9 @@ func (a *Association) handleShutdownAck(_ *chunkShutdownAck) {
 	state := a.getState()
 	if state == shutdownSent || state == shutdownAckSent {
 		a.t2Shutdown.stop()
+		a.willSendShutdown = false
+		a.willSendShutdownAck = false
+		a.shutdownCompletePending = true
 		a.willSendShutdownComplete = true
 
 		a.awakeWriteLoop()
@@ -4089,6 +4234,23 @@ func shouldAbortOnChunkValidationError(receivedChunk chunk) bool {
 	}
 }
 
+// The caller should hold the lock.
+func (a *Association) onShutdownTimeout(nRtos uint) {
+	a.log.Debugf("[%s] retransmission of shutdown timeout (nRtos=%d): %v", a.name, nRtos)
+	if a.shutdownCompletePending {
+		return
+	}
+
+	switch a.getState() {
+	case shutdownSent:
+		a.willSendShutdown = true
+		a.awakeWriteLoop()
+	case shutdownAckSent:
+		a.willSendShutdownAck = true
+		a.awakeWriteLoop()
+	}
+}
+
 func (a *Association) onRetransmissionTimeout(id int, nRtos uint) { //nolint:cyclop
 	a.lock.Lock()
 	defer a.lock.Unlock()
@@ -4112,17 +4274,9 @@ func (a *Association) onRetransmissionTimeout(id int, nRtos uint) { //nolint:cyc
 	}
 
 	if id == timerT2Shutdown {
-		a.log.Debugf("[%s] retransmission of shutdown timeout (nRtos=%d): %v", a.name, nRtos)
-		state := a.getState()
+		a.onShutdownTimeout(nRtos)
 
-		switch state {
-		case shutdownSent:
-			a.willSendShutdown = true
-			a.awakeWriteLoop()
-		case shutdownAckSent:
-			a.willSendShutdownAck = true
-			a.awakeWriteLoop()
-		}
+		return
 	}
 
 	if id == timerT3RTX { //nolint:nestif

--- a/association_test.go
+++ b/association_test.go
@@ -978,30 +978,37 @@ func TestAssociationInterleavingFinalizedOnEstablishedTransition(t *testing.T) {
 	})
 }
 
-func TestAssociationDataIgnoredBeforeEstablished(t *testing.T) {
-	assoc := createTestAssociation(t, Config{})
-	assoc.localInterleaving = true
-	assoc.peerInterleaving = true
-	assoc.useInterleaving = false
-	assoc.payloadQueue.init(0)
-	assoc.setState(cookieEchoed)
+func TestAssociationDataIgnoredOutsideReceiveStates(t *testing.T) {
+	for name, state := range map[string]uint32{
+		"before established": cookieEchoed,
+		"shutdown received":  shutdownReceived,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assoc := createTestAssociation(t, Config{})
+			assoc.localInterleaving = true
+			assoc.peerInterleaving = true
+			assoc.useInterleaving = false
+			assoc.payloadQueue.init(0)
+			assoc.setState(state)
 
-	packets := assoc.handleData(&chunkPayloadData{
-		iData:                  true,
-		messageIdentifier:      1,
-		fragmentSequenceNumber: 0,
-		beginningFragment:      true,
-		endingFragment:         true,
-		tsn:                    1,
-		streamIdentifier:       1,
-		payloadType:            PayloadTypeWebRTCBinary,
-		userData:               []byte("pre-established"),
-	})
+			packets := assoc.handleData(&chunkPayloadData{
+				iData:                  true,
+				messageIdentifier:      1,
+				fragmentSequenceNumber: 0,
+				beginningFragment:      true,
+				endingFragment:         true,
+				tsn:                    1,
+				streamIdentifier:       1,
+				payloadType:            PayloadTypeWebRTCBinary,
+				userData:               []byte("ignored"),
+			})
 
-	require.Nil(t, packets)
-	require.False(t, assoc.willSendAbort)
-	require.Equal(t, uint32(0), assoc.peerLastTSN())
-	require.Zero(t, assoc.stats.getNumDATAs())
+			require.Nil(t, packets)
+			require.False(t, assoc.willSendAbort)
+			require.Equal(t, uint32(0), assoc.peerLastTSN())
+			require.Zero(t, assoc.stats.getNumDATAs())
+		})
+	}
 }
 
 func TestAssociationDataAcknowledgedInShutdownSent(t *testing.T) {
@@ -1025,13 +1032,13 @@ func TestAssociationDataAcknowledgedInShutdownSent(t *testing.T) {
 	assert.Equal(t, uint32(1), assoc.peerLastTSN())
 	assert.True(t, assoc.immediateAckTriggered)
 	assert.True(t, assoc.willSendShutdown)
-	assert.False(t, assoc.t2Shutdown.isRunning())
+	assert.False(t, assoc.t2Shutdown.isRunning(), "T2 must stop before sending the SHUTDOWN response")
 
 	assoc.handleChunksEnd()
 	rawPackets, ok := assoc.gatherOutbound()
 	require.True(t, ok)
-	require.Len(t, rawPackets, 2)
-	assert.True(t, assoc.t2Shutdown.isRunning())
+	require.Len(t, rawPackets, 2, "expected immediate SACK followed by a SHUTDOWN response")
+	assert.True(t, assoc.t2Shutdown.isRunning(), "sending the SHUTDOWN response must restart T2")
 
 	var sackFound, shutdownFound bool
 	for _, raw := range rawPackets {
@@ -1049,6 +1056,25 @@ func TestAssociationDataAcknowledgedInShutdownSent(t *testing.T) {
 	}
 	assert.True(t, sackFound)
 	assert.True(t, shutdownFound)
+
+	assoc.handleChunksStart()
+	for streamID := uint16(2); streamID <= acceptChSize; streamID++ {
+		require.NotNil(t, assoc.createStream(streamID, true))
+	}
+	packets = assoc.handleData(&chunkPayloadData{
+		beginningFragment: true,
+		endingFragment:    true,
+		tsn:               2,
+		streamIdentifier:  acceptChSize + 1,
+		payloadType:       PayloadTypeWebRTCBinary,
+		userData:          []byte("no room for another stream"),
+	})
+
+	require.Nil(t, packets)
+	assert.Equal(t, uint32(1), assoc.peerLastTSN(), "discarded DATA must not advance the cumulative TSN")
+	assert.True(t, assoc.immediateAckTriggered)
+	assert.True(t, assoc.willSendShutdown)
+	assert.False(t, assoc.t2Shutdown.isRunning())
 }
 
 func TestAssociationShutdownProcessesCumulativeTSNAck(t *testing.T) {
@@ -1126,21 +1152,562 @@ func TestAssociationShutdownRejectsBufferedAmountLowWrite(t *testing.T) {
 	assert.True(t, assoc.willSendShutdownAck)
 }
 
+func TestAssociationShutdownUnblocksPendingWrites(t *testing.T) {
+	for name, transition := range map[string]func(*Association) error{
+		"local shutdown": func(assoc *Association) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			return assoc.Shutdown(ctx)
+		},
+		"peer shutdown": func(assoc *Association) error {
+			assoc.lock.Lock()
+			defer assoc.lock.Unlock()
+
+			return assoc.handleShutdown(&chunkShutdown{cumulativeTSNAck: 99})
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assoc := createTestAssociation(t, Config{BlockWrite: true})
+			assoc.setState(established)
+			assoc.cumulativeTSNAckPoint = 99
+			assoc.advancedPeerTSNAckPoint = 99
+			assoc.writePending = true
+			writeNotify := assoc.writeNotify
+
+			err := transition(assoc)
+			if name == "local shutdown" {
+				require.ErrorIs(t, err, context.Canceled)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.NotEqual(t, established, assoc.getState())
+			assert.False(t, assoc.writePending)
+
+			select {
+			case <-writeNotify:
+			default:
+				assert.Fail(t, "blocked writers were not notified of shutdown")
+			}
+		})
+	}
+}
+
 func TestAssociationInvalidShutdownAckDoesNotChangeState(t *testing.T) {
+	for name, state := range map[string]uint32{
+		"established":      established,
+		"shutdown pending": shutdownPending,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assoc := createTestAssociation(t, Config{BlockWrite: state == established})
+			assoc.setState(state)
+			assoc.cumulativeTSNAckPoint = 99
+			assoc.inflightQueue.pushNoCheck(mkChunk(100, time.Now()))
+			var writeNotify chan struct{}
+			if state == established {
+				assoc.writePending = true
+				writeNotify = assoc.writeNotify
+			}
+
+			assoc.lock.Lock()
+			err := assoc.handleShutdown(&chunkShutdown{cumulativeTSNAck: 101})
+			assoc.lock.Unlock()
+
+			require.ErrorIs(t, err, ErrInflightQueueTSNPop)
+			assert.Equal(t, state, assoc.getState())
+			assert.Equal(t, uint32(99), assoc.cumulativeTSNAckPoint)
+			assert.Equal(t, 1, assoc.inflightQueue.size())
+			assert.False(t, assoc.willSendShutdownAck)
+			if state == established {
+				assert.True(t, assoc.writePending)
+				select {
+				case <-writeNotify:
+					assert.Fail(t, "invalid shutdown notified blocked writers")
+				default:
+				}
+			}
+		})
+	}
+}
+
+func TestAssociationCrossedShutdownClearsPendingShutdown(t *testing.T) {
 	assoc := createTestAssociation(t, Config{})
-	assoc.setState(established)
 	assoc.cumulativeTSNAckPoint = 99
-	assoc.inflightQueue.pushNoCheck(mkChunk(100, time.Now()))
+	assoc.setState(shutdownSent)
+	assoc.willSendShutdown = true
+	require.True(t, assoc.t2Shutdown.start(1000))
+	t.Cleanup(assoc.t2Shutdown.close)
 
 	assoc.lock.Lock()
-	err := assoc.handleShutdown(&chunkShutdown{cumulativeTSNAck: 101})
+	err := assoc.handleShutdown(&chunkShutdown{cumulativeTSNAck: 99})
 	assoc.lock.Unlock()
 
-	require.ErrorIs(t, err, ErrInflightQueueTSNPop)
-	assert.Equal(t, established, assoc.getState())
-	assert.Equal(t, uint32(99), assoc.cumulativeTSNAckPoint)
-	assert.Equal(t, 1, assoc.inflightQueue.size())
+	require.NoError(t, err)
+	assert.Equal(t, shutdownAckSent, assoc.getState())
+	assert.False(t, assoc.willSendShutdown)
+	assert.True(t, assoc.willSendShutdownAck)
+	assert.False(t, assoc.t2Shutdown.isRunning())
+
+	rawPackets, ok := assoc.gatherOutbound()
+	require.True(t, ok)
+	require.Len(t, rawPackets, 1)
+	assert.True(t, assoc.t2Shutdown.isRunning())
+
+	packet := &packet{}
+	require.NoError(t, packet.unmarshal(false, rawPackets[0]))
+	require.Len(t, packet.chunks, 1)
+	require.IsType(t, &chunkShutdownAck{}, packet.chunks[0])
+	assert.False(t, assoc.willSendShutdown)
 	assert.False(t, assoc.willSendShutdownAck)
+
+	rawPackets, ok = assoc.gatherOutbound()
+	assert.True(t, ok)
+	assert.Empty(t, rawPackets)
+}
+
+func TestAssociationRepeatedShutdownRetransmitsAck(t *testing.T) {
+	assoc := createTestAssociation(t, Config{})
+	assoc.setState(shutdownAckSent)
+	require.True(t, assoc.t2Shutdown.start(1000))
+	t.Cleanup(assoc.t2Shutdown.close)
+
+	assoc.lock.Lock()
+	err := assoc.handleShutdown(&chunkShutdown{})
+	assoc.lock.Unlock()
+
+	require.NoError(t, err)
+	assert.Equal(t, shutdownAckSent, assoc.getState())
+	assert.True(t, assoc.willSendShutdownAck)
+	assert.False(t, assoc.t2Shutdown.isRunning())
+
+	rawPackets, ok := assoc.gatherOutbound()
+	require.True(t, ok)
+	require.Len(t, rawPackets, 1)
+	assert.True(t, assoc.t2Shutdown.isRunning())
+
+	pkt := &packet{}
+	require.NoError(t, pkt.unmarshal(false, rawPackets[0]))
+	require.Len(t, pkt.chunks, 1)
+	require.IsType(t, &chunkShutdownAck{}, pkt.chunks[0])
+}
+
+func TestAssociationShutdownAckPrioritizedOverControlQueue(t *testing.T) {
+	assoc := createTestAssociation(t, Config{})
+	assoc.setState(shutdownAckSent)
+	assoc.willSendShutdownAck = true
+	assoc.controlQueue.push(assoc.createPacket([]chunk{&chunkCookieAck{}}))
+	t.Cleanup(assoc.t2Shutdown.close)
+
+	rawPackets, ok := assoc.gatherOutbound()
+	require.True(t, ok)
+	require.Len(t, rawPackets, 2)
+	assert.True(t, assoc.t2Shutdown.isRunning())
+
+	shutdownAckPacket := &packet{}
+	require.NoError(t, shutdownAckPacket.unmarshal(false, rawPackets[0]))
+	require.Len(t, shutdownAckPacket.chunks, 1)
+	require.IsType(t, &chunkShutdownAck{}, shutdownAckPacket.chunks[0])
+
+	controlPacket := &packet{}
+	require.NoError(t, controlPacket.unmarshal(false, rawPackets[1]))
+	require.Len(t, controlPacket.chunks, 1)
+	require.IsType(t, &chunkCookieAck{}, controlPacket.chunks[0])
+}
+
+func TestAssociationShutdownPrioritizedOverControlQueue(t *testing.T) {
+	assoc := createTestAssociation(t, Config{})
+	assoc.payloadQueue.init(0)
+	assoc.setState(shutdownSent)
+	assoc.willSendShutdown = true
+	assoc.ackState = ackStateImmediate
+	assoc.controlQueue.push(assoc.createPacket([]chunk{&chunkCookieAck{}}))
+	t.Cleanup(assoc.t2Shutdown.close)
+
+	rawPackets, ok := assoc.gatherOutbound()
+	require.True(t, ok)
+	require.Len(t, rawPackets, 3)
+	assert.True(t, assoc.t2Shutdown.isRunning())
+
+	expected := []chunk{
+		&chunkSelectiveAck{},
+		&chunkShutdown{},
+		&chunkCookieAck{},
+	}
+	for i, expectedChunk := range expected {
+		packet := &packet{}
+		require.NoError(t, packet.unmarshal(false, rawPackets[i]))
+		require.Len(t, packet.chunks, 1)
+		require.IsType(t, expectedChunk, packet.chunks[0])
+	}
+}
+
+func TestAssociationShutdownAckClearsPendingShutdownResponses(t *testing.T) {
+	for name, test := range map[string]struct {
+		state               uint32
+		willSendShutdown    bool
+		willSendShutdownAck bool
+	}{
+		"shutdown sent": {
+			state:            shutdownSent,
+			willSendShutdown: true,
+		},
+		"shutdown ack sent": {
+			state:               shutdownAckSent,
+			willSendShutdownAck: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assoc := createTestAssociation(t, Config{})
+			assoc.setState(test.state)
+			assoc.willSendShutdown = test.willSendShutdown
+			assoc.willSendShutdownAck = test.willSendShutdownAck
+
+			assoc.lock.Lock()
+			assoc.handleShutdownAck(&chunkShutdownAck{})
+			assoc.lock.Unlock()
+
+			assert.False(t, assoc.willSendShutdown)
+			assert.False(t, assoc.willSendShutdownAck)
+			assert.True(t, assoc.willSendShutdownComplete)
+
+			assoc.willSendShutdown = true
+			assoc.willSendShutdownAck = true
+
+			rawPackets, ok := assoc.gatherOutbound()
+			require.False(t, ok)
+			require.Len(t, rawPackets, 1)
+
+			packet := &packet{}
+			require.NoError(t, packet.unmarshal(false, rawPackets[0]))
+			require.Len(t, packet.chunks, 1)
+			require.IsType(t, &chunkShutdownComplete{}, packet.chunks[0])
+		})
+	}
+}
+
+func TestAssociationShutdownCompleteWinsOverLateData(t *testing.T) {
+	assoc := createTestAssociation(t, Config{})
+	assoc.payloadQueue.init(0)
+	assoc.setState(shutdownSent)
+
+	assoc.lock.Lock()
+	assoc.handleShutdownAck(&chunkShutdownAck{})
+	packets := assoc.handleData(&chunkPayloadData{
+		beginningFragment: true,
+		endingFragment:    true,
+		tsn:               0,
+		streamIdentifier:  1,
+		payloadType:       PayloadTypeWebRTCBinary,
+		userData:          []byte("late duplicate"),
+	})
+	assoc.lock.Unlock()
+
+	require.Nil(t, packets)
+	assoc.handleChunksEnd()
+
+	assert.True(t, assoc.willSendShutdownComplete)
+	assert.False(t, assoc.willSendShutdown)
+	assert.False(t, assoc.immediateAckTriggered)
+	assert.Zero(t, assoc.stats.getNumDATAs())
+
+	rawPackets, ok := assoc.gatherOutbound()
+	require.False(t, ok)
+	require.Len(t, rawPackets, 1)
+
+	packet := &packet{}
+	require.NoError(t, packet.unmarshal(false, rawPackets[0]))
+	require.Len(t, packet.chunks, 1)
+	require.IsType(t, &chunkShutdownComplete{}, packet.chunks[0])
+	assert.False(t, assoc.willSendShutdownComplete)
+	assert.True(t, assoc.shutdownCompletePending)
+	assert.False(t, assoc.t2Shutdown.isRunning())
+
+	assoc.lock.Lock()
+	packets = assoc.handleData(&chunkPayloadData{
+		beginningFragment: true,
+		endingFragment:    true,
+		tsn:               0,
+		streamIdentifier:  1,
+		payloadType:       PayloadTypeWebRTCBinary,
+		userData:          []byte("late after gather"),
+	})
+	assoc.lock.Unlock()
+
+	assert.Nil(t, packets)
+	assert.False(t, assoc.willSendShutdown)
+	assert.Zero(t, assoc.stats.getNumDATAs())
+}
+
+func TestAssociationShutdownCompleteWinsOverLateT2Timeout(t *testing.T) {
+	for name, state := range map[string]uint32{
+		"shutdown sent":     shutdownSent,
+		"shutdown ack sent": shutdownAckSent,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assoc := createTestAssociation(t, Config{})
+			assoc.setState(state)
+			require.True(t, assoc.t2Shutdown.start(1000))
+			t.Cleanup(assoc.t2Shutdown.close)
+
+			assoc.lock.Lock()
+			assoc.handleShutdownAck(&chunkShutdownAck{})
+			assoc.lock.Unlock()
+
+			assoc.onRetransmissionTimeout(timerT2Shutdown, 1)
+
+			assert.True(t, assoc.willSendShutdownComplete)
+			assert.False(t, assoc.willSendShutdown)
+			assert.False(t, assoc.willSendShutdownAck)
+			assert.False(t, assoc.t2Shutdown.isRunning())
+
+			rawPackets, ok := assoc.gatherOutbound()
+			require.False(t, ok)
+			require.Len(t, rawPackets, 1)
+
+			packet := &packet{}
+			require.NoError(t, packet.unmarshal(false, rawPackets[0]))
+			require.Len(t, packet.chunks, 1)
+			require.IsType(t, &chunkShutdownComplete{}, packet.chunks[0])
+
+			assoc.onRetransmissionTimeout(timerT2Shutdown, 2)
+			assert.False(t, assoc.willSendShutdown)
+			assert.False(t, assoc.willSendShutdownAck)
+		})
+	}
+}
+
+func TestAssociationShutdownDrainsPendingData(t *testing.T) {
+	assoc := createTestAssociation(t, Config{})
+	assoc.setState(established)
+	assoc.initialTSN = 100
+	assoc.myNextTSN = 100
+	assoc.cumulativeTSNAckPoint = 99
+	assoc.advancedPeerTSNAckPoint = 99
+	assoc.setRWND(1024)
+	t.Cleanup(assoc.closeAllTimers)
+
+	assoc.pendingQueue.push(&chunkPayloadData{
+		beginningFragment: true,
+		endingFragment:    true,
+		streamIdentifier:  1,
+		payloadType:       PayloadTypeWebRTCBinary,
+		userData:          []byte("queued before shutdown"),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, assoc.Shutdown(ctx), context.Canceled)
+	assert.Equal(t, shutdownPending, assoc.getState())
+	assert.False(t, assoc.willSendShutdown)
+
+	rawPackets, ok := assoc.gatherOutbound()
+	require.True(t, ok)
+	require.Len(t, rawPackets, 1)
+
+	pkt := &packet{}
+	require.NoError(t, pkt.unmarshal(false, rawPackets[0]))
+	require.Len(t, pkt.chunks, 1)
+	data, ok := pkt.chunks[0].(*chunkPayloadData)
+	require.True(t, ok)
+	assert.Equal(t, uint32(100), data.tsn)
+	assert.Zero(t, assoc.pendingQueue.size())
+	assert.Equal(t, 1, assoc.inflightQueue.size())
+	assert.Equal(t, shutdownPending, assoc.getState())
+
+	assoc.lock.Lock()
+	err := assoc.handleSack(&chunkSelectiveAck{
+		cumulativeTSNAck:               100,
+		advertisedReceiverWindowCredit: 1024,
+	})
+	assoc.lock.Unlock()
+	require.NoError(t, err)
+	assert.Equal(t, shutdownSent, assoc.getState())
+	assert.True(t, assoc.willSendShutdown)
+
+	rawPackets, ok = assoc.gatherOutbound()
+	require.True(t, ok)
+	require.Len(t, rawPackets, 1)
+
+	pkt = &packet{}
+	require.NoError(t, pkt.unmarshal(false, rawPackets[0]))
+	require.Len(t, pkt.chunks, 1)
+	require.IsType(t, &chunkShutdown{}, pkt.chunks[0])
+}
+
+func TestAssociationCrossedShutdownDrainsPendingData(t *testing.T) {
+	assoc := createTestAssociation(t, Config{})
+	assoc.setState(shutdownPending)
+	assoc.initialTSN = 100
+	assoc.myNextTSN = 100
+	assoc.cumulativeTSNAckPoint = 99
+	assoc.advancedPeerTSNAckPoint = 99
+	assoc.setRWND(1024)
+	t.Cleanup(assoc.closeAllTimers)
+
+	assoc.pendingQueue.push(&chunkPayloadData{
+		beginningFragment: true,
+		endingFragment:    true,
+		streamIdentifier:  1,
+		payloadType:       PayloadTypeWebRTCBinary,
+		userData:          []byte("queued before crossed shutdown"),
+	})
+
+	assoc.lock.Lock()
+	err := assoc.handleShutdown(&chunkShutdown{cumulativeTSNAck: 99})
+	assoc.lock.Unlock()
+	require.NoError(t, err)
+	assert.Equal(t, shutdownReceived, assoc.getState())
+	assert.False(t, assoc.willSendShutdown)
+	assert.False(t, assoc.willSendShutdownAck)
+
+	rawPackets, ok := assoc.gatherOutbound()
+	require.True(t, ok)
+	require.Len(t, rawPackets, 1)
+
+	pkt := &packet{}
+	require.NoError(t, pkt.unmarshal(false, rawPackets[0]))
+	require.Len(t, pkt.chunks, 1)
+	data, ok := pkt.chunks[0].(*chunkPayloadData)
+	require.True(t, ok)
+	assert.Equal(t, uint32(100), data.tsn)
+	assert.Zero(t, assoc.pendingQueue.size())
+	assert.Equal(t, 1, assoc.inflightQueue.size())
+
+	assoc.lock.Lock()
+	err = assoc.handleSack(&chunkSelectiveAck{
+		cumulativeTSNAck:               100,
+		advertisedReceiverWindowCredit: 1024,
+	})
+	assoc.lock.Unlock()
+	require.NoError(t, err)
+	assert.Equal(t, shutdownAckSent, assoc.getState())
+	assert.True(t, assoc.willSendShutdownAck)
+
+	rawPackets, ok = assoc.gatherOutbound()
+	require.True(t, ok)
+	require.Len(t, rawPackets, 1)
+
+	pkt = &packet{}
+	require.NoError(t, pkt.unmarshal(false, rawPackets[0]))
+	require.Len(t, pkt.chunks, 1)
+	require.IsType(t, &chunkShutdownAck{}, pkt.chunks[0])
+}
+
+func TestAssociationSendsForwardTSNWhileDrainingShutdown(t *testing.T) {
+	for name, state := range map[string]uint32{
+		"shutdown pending":  shutdownPending,
+		"shutdown received": shutdownReceived,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assoc := createTestAssociation(t, Config{})
+			assoc.setState(state)
+			assoc.useForwardTSN = true
+			assoc.cumulativeTSNAckPoint = 9
+			assoc.advancedPeerTSNAckPoint = 9
+			assoc.inflightQueue.pushNoCheck(&chunkPayloadData{
+				beginningFragment:    true,
+				endingFragment:       true,
+				tsn:                  10,
+				streamIdentifier:     1,
+				streamSequenceNumber: 2,
+				userData:             []byte("abandoned"),
+				nSent:                1,
+				_abandoned:           true,
+				_allInflight:         true,
+			})
+
+			assoc.lock.Lock()
+			err := assoc.finishAcknowledgement(
+				&chunkSelectiveAck{cumulativeTSNAck: 9},
+				acknowledgementResult{htna: 9},
+			)
+			assoc.lock.Unlock()
+			require.NoError(t, err)
+			require.Equal(t, uint32(10), assoc.advancedPeerTSNAckPoint)
+			require.True(t, assoc.willSendForwardTSN)
+
+			rawPackets, ok := assoc.gatherOutbound()
+			require.True(t, ok)
+			require.Len(t, rawPackets, 1)
+
+			pkt := &packet{}
+			require.NoError(t, pkt.unmarshal(false, rawPackets[0]))
+			require.Len(t, pkt.chunks, 1)
+			forwardTSN, ok := pkt.chunks[0].(*chunkForwardTSN)
+			require.True(t, ok)
+			assert.Equal(t, uint32(10), forwardTSN.newCumulativeTSN)
+			assert.False(t, assoc.willSendForwardTSN)
+		})
+	}
+}
+
+func TestAssociationShutdownAdvancesAfterPendingStreamReset(t *testing.T) {
+	for name, test := range map[string]struct {
+		state         uint32
+		expectedState uint32
+		expectedChunk chunk
+	}{
+		"shutdown pending": {
+			state:         shutdownPending,
+			expectedState: shutdownSent,
+			expectedChunk: &chunkShutdown{},
+		},
+		"shutdown received": {
+			state:         shutdownReceived,
+			expectedState: shutdownAckSent,
+			expectedChunk: &chunkShutdownAck{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assoc := createTestAssociation(t, Config{})
+			assoc.setState(test.state)
+			assoc.myNextTSN = 100
+			t.Cleanup(assoc.closeAllTimers)
+
+			assoc.pendingQueue.push(&chunkPayloadData{
+				beginningFragment: true,
+				endingFragment:    true,
+				streamIdentifier:  1,
+			})
+
+			rawPackets, ok := assoc.gatherOutbound()
+			require.True(t, ok)
+			require.Len(t, rawPackets, 2)
+			assert.Equal(t, test.expectedState, assoc.getState())
+			assert.Zero(t, assoc.pendingQueue.size())
+			assert.Zero(t, assoc.inflightQueue.size())
+
+			reconfigPacket := &packet{}
+			require.NoError(t, reconfigPacket.unmarshal(false, rawPackets[0]))
+			require.Len(t, reconfigPacket.chunks, 1)
+			require.IsType(t, &chunkReconfig{}, reconfigPacket.chunks[0])
+
+			shutdownPacket := &packet{}
+			require.NoError(t, shutdownPacket.unmarshal(false, rawPackets[1]))
+			require.Len(t, shutdownPacket.chunks, 1)
+			require.IsType(t, test.expectedChunk, shutdownPacket.chunks[0])
+
+			assoc.onRetransmissionTimeout(timerReconfig, 1)
+			assoc.onRetransmissionTimeout(timerT2Shutdown, 1)
+			require.True(t, assoc.willRetransmitReconfig)
+
+			rawPackets, ok = assoc.gatherOutbound()
+			require.True(t, ok)
+			require.Len(t, rawPackets, 2)
+			assert.Equal(t, test.expectedState, assoc.getState())
+			assert.False(t, assoc.willRetransmitReconfig)
+
+			retransmittedShutdown := &packet{}
+			require.NoError(t, retransmittedShutdown.unmarshal(false, rawPackets[0]))
+			require.Len(t, retransmittedShutdown.chunks, 1)
+			require.IsType(t, test.expectedChunk, retransmittedShutdown.chunks[0])
+
+			retransmitted := &packet{}
+			require.NoError(t, retransmitted.unmarshal(false, rawPackets[1]))
+			require.Len(t, retransmitted.chunks, 1)
+			require.IsType(t, &chunkReconfig{}, retransmitted.chunks[0])
+		})
+	}
 }
 
 func TestAssociationShutdownSentRespondsToInvalidCumulativeTSNAck(t *testing.T) {
@@ -4126,8 +4693,87 @@ func TestAssocHandleInit(t *testing.T) {
 		handleInitTest(t, established, true)
 	})
 
-	t.Run("unexpected state shutdownAckSent", func(t *testing.T) {
-		handleInitTest(t, shutdownAckSent, true)
+	t.Run("shutdownAckSent matching ports retransmits shutdown ack", func(t *testing.T) {
+		assoc := createTestAssociation(t, Config{
+			NetConn:       &dumbConn{},
+			LoggerFactory: loggerFactory,
+		})
+		assoc.setState(shutdownAckSent)
+		assoc.sourcePort = 5002
+		assoc.destinationPort = 5001
+		assoc.willSendShutdown = true
+		require.True(t, assoc.t2Shutdown.start(1000))
+		t.Cleanup(assoc.t2Shutdown.close)
+
+		pkt := &packet{
+			sourcePort:      5001,
+			destinationPort: 5002,
+		}
+		init := &chunkInit{
+			chunkInitCommon: chunkInitCommon{
+				initialTSN:                     1234,
+				numOutboundStreams:             1001,
+				numInboundStreams:              1002,
+				initiateTag:                    5678,
+				advertisedReceiverWindowCredit: 512 * 1024,
+			},
+		}
+
+		packets, err := assoc.handleInit(pkt, init)
+		require.NoError(t, err)
+		assert.Empty(t, packets)
+		assert.Equal(t, shutdownAckSent, assoc.getState())
+		assert.False(t, assoc.willSendShutdown)
+		assert.True(t, assoc.willSendShutdownAck)
+		assert.False(t, assoc.t2Shutdown.isRunning())
+
+		rawPackets, ok := assoc.gatherOutbound()
+		require.True(t, ok)
+		require.Len(t, rawPackets, 1)
+		assert.True(t, assoc.t2Shutdown.isRunning())
+
+		shutdownAckPacket := &packet{}
+		require.NoError(t, shutdownAckPacket.unmarshal(false, rawPackets[0]))
+		require.Len(t, shutdownAckPacket.chunks, 1)
+		require.IsType(t, &chunkShutdownAck{}, shutdownAckPacket.chunks[0])
+	})
+
+	t.Run("shutdownAckSent mismatched ports does not retransmit shutdown ack", func(t *testing.T) {
+		assoc := createTestAssociation(t, Config{
+			NetConn:       &dumbConn{},
+			LoggerFactory: loggerFactory,
+		})
+		assoc.setState(shutdownAckSent)
+		assoc.sourcePort = 6002
+		assoc.destinationPort = 6001
+		require.True(t, assoc.t2Shutdown.start(1000))
+		t.Cleanup(assoc.t2Shutdown.close)
+
+		pkt := &packet{
+			sourcePort:      5001,
+			destinationPort: 5002,
+		}
+		init := &chunkInit{
+			chunkInitCommon: chunkInitCommon{
+				initialTSN:                     1234,
+				numOutboundStreams:             1001,
+				numInboundStreams:              1002,
+				initiateTag:                    5678,
+				advertisedReceiverWindowCredit: 512 * 1024,
+			},
+		}
+
+		packets, err := assoc.handleInit(pkt, init)
+		require.NoError(t, err)
+		assert.Empty(t, packets)
+		assert.Equal(t, shutdownAckSent, assoc.getState())
+		assert.False(t, assoc.willSendShutdown)
+		assert.False(t, assoc.willSendShutdownAck)
+		assert.True(t, assoc.t2Shutdown.isRunning())
+
+		rawPackets, ok := assoc.gatherOutbound()
+		assert.True(t, ok)
+		assert.Empty(t, rawPackets)
 	})
 
 	t.Run("unexpected state shutdownPending", func(t *testing.T) {


### PR DESCRIPTION
#### Description
this commit was first added to #481 while i was interop testing it, and continues from #482 
This is the final fix for the graceful shutdown and makes the state linear ESTABLISHED => SHUTDOWN-PENDING => drain queued/inflight data => SHUTDOWN-SENT => SHUTDOWN-COMPLETE => CLOSED.
it also handles some edge cases while doing graceful shutdown, like if both peers shutdown simultaneously. and prevents late DATA from restarting shutdown.

The diff seems noisy because i added many tests.