### PR TITLE
Make SCTP stream reset and reuse generation-safe

### DIFF
--- a/association.go
+++ b/association.go
@@ -283,6 +283,7 @@ type Association struct {
 	reconfigs                    map[uint32]*chunkReconfig
 	reconfigRequests             map[uint32]*paramOutgoingResetRequest
 	onStreamResetCompleteHandler func(streamID uint16)
+	streamResetStates            map[uint16]streamResetState
 
 	// Non-RFC internal data
 	sourcePort              uint16
@@ -849,6 +850,7 @@ func createAssociationFromConfigWithTsn(cfg *Config, tsn uint32) *Association {
 		streams:                 map[uint16]*Stream{},
 		reconfigs:               map[uint32]*chunkReconfig{},
 		reconfigRequests:        map[uint32]*paramOutgoingResetRequest{},
+		streamResetStates:       map[uint16]streamResetState{},
 		acceptCh:                make(chan *Stream, acceptChSize),
 		readLoopCloseCh:         make(chan struct{}),
 		awakeWriteLoopCh:        make(chan struct{}, 1),
@@ -3692,7 +3694,7 @@ func (a *Association) handleReconfigParam(raw param) (*packet, error) {
 			return nil, nil //nolint:nilnil
 		}
 		if par.result == reconfigResultSuccessPerformed {
-			a.resetOutgoingStreamSequenceNumbers(par.reconfigResponseSequenceNumber)
+			a.completeOutgoingStreamReset(par.reconfigResponseSequenceNumber)
 		}
 		delete(a.reconfigs, par.reconfigResponseSequenceNumber)
 		if len(a.reconfigs) == 0 {
@@ -3706,7 +3708,7 @@ func (a *Association) handleReconfigParam(raw param) (*packet, error) {
 }
 
 // The caller should hold the lock.
-func (a *Association) resetOutgoingStreamSequenceNumbers(reconfigRequestSequenceNumber uint32) {
+func (a *Association) completeOutgoingStreamReset(reconfigRequestSequenceNumber uint32) {
 	reconfig := a.reconfigs[reconfigRequestSequenceNumber]
 	if reconfig == nil {
 		return
@@ -3719,6 +3721,7 @@ func (a *Association) resetOutgoingStreamSequenceNumbers(reconfigRequestSequence
 		if s, ok := a.streams[id]; ok {
 			s.resetOutgoingStreamSequenceNumbers()
 		}
+		a.completeStreamResetDirection(id, streamResetOutbound)
 	}
 }
 
@@ -3738,13 +3741,7 @@ func (a *Association) resetStreamsIfAny(resetRequest *paramOutgoingResetRequest)
 			a.lock.Lock()
 			a.log.Debugf("[%s] deleting stream %d", a.name, id)
 			delete(a.streams, s.streamIdentifier)
-			streamResetCompleteHandler := a.onStreamResetCompleteHandler
-			if streamResetCompleteHandler != nil {
-				streamID := s.streamIdentifier
-				a.lock.Unlock()
-				streamResetCompleteHandler(streamID)
-				a.lock.Lock()
-			}
+			a.completeStreamResetDirection(s.streamIdentifier, streamResetInbound)
 		}
 		delete(a.reconfigRequests, resetRequest.reconfigRequestSequenceNumber)
 	} else {
@@ -3759,6 +3756,35 @@ func (a *Association) resetStreamsIfAny(resetRequest *paramOutgoingResetRequest)
 			result:                         result,
 		},
 	}})
+}
+
+type streamResetState uint8
+
+const (
+	streamResetInbound streamResetState = 1 << iota
+	streamResetOutbound
+	streamResetBoth = streamResetInbound | streamResetOutbound
+)
+
+// The caller should hold the association lock.
+func (a *Association) completeStreamResetDirection(streamID uint16, direction streamResetState) {
+	if a.streamResetStates == nil {
+		a.streamResetStates = map[uint16]streamResetState{}
+	}
+	state := a.streamResetStates[streamID] | direction
+	if state != streamResetBoth {
+		a.streamResetStates[streamID] = state
+		return
+	}
+	delete(a.streamResetStates, streamID)
+	handler := a.onStreamResetCompleteHandler
+	if handler == nil {
+		return
+	}
+
+	a.lock.Unlock()
+	handler(streamID)
+	a.lock.Lock()
 }
 
 // Move the chunk peeked with a.pendingQueue.peek() to the inflightQueue.
@@ -4459,8 +4485,8 @@ func (a *Association) SetMaxMessageSize(maxMsgSize uint32) {
 	atomic.StoreUint32(&a.maxMessageSize, maxMsgSize)
 }
 
-// OnStreamResetComplete sets a handler invoked after an incoming stream reset
-// completes and the stream has been removed from the association.
+// OnStreamResetComplete sets a handler invoked after both directions of a
+// stream reset complete and the stream has been removed from the association.
 func (a *Association) OnStreamResetComplete(f func(streamID uint16)) {
 	a.lock.Lock()
 	defer a.lock.Unlock()

--- a/association.go
+++ b/association.go
@@ -131,6 +131,12 @@ type AssociationMetadata struct {
 
 	// ZeroChecksumReceivingEnabled indicates whether incoming packets may use zero checksum.
 	ZeroChecksumReceivingEnabled bool `json:"zeroChecksumReceivingEnabled"`
+
+	// NumInboundStreams is the negotiated maximum number of inbound streams.
+	NumInboundStreams uint16 `json:"numInboundStreams"`
+
+	// NumOutboundStreams is the negotiated maximum number of outbound streams.
+	NumOutboundStreams uint16 `json:"numOutboundStreams"`
 }
 
 // association state enums.
@@ -273,15 +279,18 @@ type Association struct {
 	abortSentCh        chan struct{}
 
 	// Reconfig
-	myNextRSN        uint32
-	reconfigs        map[uint32]*chunkReconfig
-	reconfigRequests map[uint32]*paramOutgoingResetRequest
+	myNextRSN                    uint32
+	reconfigs                    map[uint32]*chunkReconfig
+	reconfigRequests             map[uint32]*paramOutgoingResetRequest
+	onStreamResetCompleteHandler func(streamID uint16)
 
 	// Non-RFC internal data
 	sourcePort              uint16
 	destinationPort         uint16
-	myMaxNumInboundStreams  uint16
-	myMaxNumOutboundStreams uint16
+	localInboundStreams     uint16
+	localOutboundStreams    uint16
+	peerInboundStreams      uint16
+	peerOutboundStreams     uint16
 	myCookie                *paramStateCookie
 	payloadQueue            *receivePayloadQueue
 	inflightQueue           *payloadQueue
@@ -417,6 +426,10 @@ type Config struct {
 	FastRtxWnd uint32
 	// Step of congestion window increase at Congestion Avoidance
 	CwndCAStep uint32
+	// NumInboundStreams is the maximum number of inbound streams to negotiate.
+	NumInboundStreams uint16
+	// NumOutboundStreams is the maximum number of outbound streams to negotiate.
+	NumOutboundStreams uint16
 
 	// RACK config options
 	rack rackSettings
@@ -543,6 +556,12 @@ func (c *Config) applyDefaults() {
 	if c.MTU == 0 {
 		c.MTU = initialMTU
 	}
+	if c.NumInboundStreams == 0 {
+		c.NumInboundStreams = math.MaxUint16
+	}
+	if c.NumOutboundStreams == 0 {
+		c.NumOutboundStreams = math.MaxUint16
+	}
 	if !c.enableInterleavingSet {
 		c.enableInterleaving = true
 	}
@@ -664,8 +683,8 @@ func (a *Association) initClient() {
 
 	init := &chunkInit{}
 	init.initialTSN = a.myNextTSN
-	init.numOutboundStreams = a.myMaxNumOutboundStreams
-	init.numInboundStreams = a.myMaxNumInboundStreams
+	init.numOutboundStreams = a.localOutboundStreams
+	init.numInboundStreams = a.localInboundStreams
 	init.initiateTag = a.myVerificationTag
 	init.advertisedReceiverWindowCredit = a.maxReceiveBufferSize
 	setSupportedExtensions(&init.chunkInitCommon, a.localInterleaving)
@@ -811,8 +830,8 @@ func createAssociationFromConfigWithTsn(cfg *Config, tsn uint32) *Association {
 		fastRtxWnd:                cfg.FastRtxWnd,
 		cwndCAStep:                cfg.CwndCAStep,
 
-		myMaxNumOutboundStreams: math.MaxUint16,
-		myMaxNumInboundStreams:  math.MaxUint16,
+		localInboundStreams:  cfg.NumInboundStreams,
+		localOutboundStreams: cfg.NumOutboundStreams,
 
 		payloadQueue:            newReceivePayloadQueue(getMaxTSNOffset(maxReceiveBufferSize)),
 		inflightQueue:           newPayloadQueue(),
@@ -896,8 +915,10 @@ func (a *Association) initWithOutOfBandTokens(localInit *chunkInit, remoteInit *
 	go a.writeLoop()
 
 	a.payloadQueue.init(remoteInit.initialTSN - 1)
-	a.myMaxNumInboundStreams = min16(localInit.numInboundStreams, remoteInit.numInboundStreams)
-	a.myMaxNumOutboundStreams = min16(localInit.numOutboundStreams, remoteInit.numOutboundStreams)
+	a.localInboundStreams = localInit.numInboundStreams
+	a.localOutboundStreams = localInit.numOutboundStreams
+	a.peerInboundStreams = remoteInit.numInboundStreams
+	a.peerOutboundStreams = remoteInit.numOutboundStreams
 	a.setRWND(remoteInit.advertisedReceiverWindowCredit)
 	a.peerVerificationTag = remoteInit.initiateTag
 	a.sourcePort = defaultSCTPSrcDstPort
@@ -1925,12 +1946,16 @@ func (a *Association) Metadata() (AssociationMetadata, bool) {
 	case a.useForwardTSN:
 		partialReliabilityMode = PartialReliabilityModeForwardTSN
 	}
+	numInboundStreams := min16(a.localInboundStreams, a.peerOutboundStreams)
+	numOutboundStreams := min16(a.localOutboundStreams, a.peerInboundStreams)
 
 	return AssociationMetadata{
 		MessageInterleavingEnabled:   a.useInterleaving,
 		PartialReliabilityMode:       partialReliabilityMode,
 		ZeroChecksumSendingEnabled:   a.sendZeroChecksum,
 		ZeroChecksumReceivingEnabled: a.recvZeroChecksum,
+		NumInboundStreams:            numInboundStreams,
+		NumOutboundStreams:           numOutboundStreams,
 	}, true
 }
 
@@ -2079,8 +2104,8 @@ func (a *Association) handleInit(pkt *packet, initChunk *chunkInit) ([]*packet, 
 	// our cookie is not compliant with https://www.rfc-editor.org/rfc/rfc9260#section-5.1-2.2.3.
 	// It makes us more vulnerable to resource attacks, albeit minimally so.
 	//  https://www.rfc-editor.org/rfc/rfc9260#sec_handle_stream_parameters
-	a.myMaxNumInboundStreams = min16(initChunk.numInboundStreams, a.myMaxNumInboundStreams)
-	a.myMaxNumOutboundStreams = min16(initChunk.numOutboundStreams, a.myMaxNumOutboundStreams)
+	a.peerInboundStreams = initChunk.numInboundStreams
+	a.peerOutboundStreams = initChunk.numOutboundStreams
 	a.peerVerificationTag = initChunk.initiateTag
 	a.sourcePort = pkt.destinationPort
 	a.destinationPort = pkt.sourcePort
@@ -2133,8 +2158,8 @@ func (a *Association) handleInit(pkt *packet, initChunk *chunkInit) ([]*packet, 
 	a.log.Debug("sending INIT ACK")
 
 	initAck.initialTSN = a.myNextTSN
-	initAck.numOutboundStreams = a.myMaxNumOutboundStreams
-	initAck.numInboundStreams = a.myMaxNumInboundStreams
+	initAck.numOutboundStreams = min16(a.localOutboundStreams, a.peerInboundStreams)
+	initAck.numInboundStreams = min16(a.localInboundStreams, a.peerOutboundStreams)
 	initAck.initiateTag = a.myVerificationTag
 	initAck.advertisedReceiverWindowCredit = a.maxReceiveBufferSize
 
@@ -2175,8 +2200,8 @@ func (a *Association) handleInitAck(pkt *packet, initChunkAck *chunkInitAck) err
 		return nil
 	}
 
-	a.myMaxNumInboundStreams = min16(initChunkAck.numInboundStreams, a.myMaxNumInboundStreams)
-	a.myMaxNumOutboundStreams = min16(initChunkAck.numOutboundStreams, a.myMaxNumOutboundStreams)
+	a.peerInboundStreams = initChunkAck.numInboundStreams
+	a.peerOutboundStreams = initChunkAck.numOutboundStreams
 	a.peerVerificationTag = initChunkAck.initiateTag
 	a.payloadQueue.init(initChunkAck.initialTSN - 1)
 	if a.sourcePort != pkt.destinationPort ||
@@ -3707,6 +3732,13 @@ func (a *Association) resetStreamsIfAny(resetRequest *paramOutgoingResetRequest)
 			a.lock.Lock()
 			a.log.Debugf("[%s] deleting stream %d", a.name, id)
 			delete(a.streams, s.streamIdentifier)
+			streamResetCompleteHandler := a.onStreamResetCompleteHandler
+			if streamResetCompleteHandler != nil {
+				streamID := s.streamIdentifier
+				a.lock.Unlock()
+				streamResetCompleteHandler(streamID)
+				a.lock.Lock()
+			}
 		}
 		delete(a.reconfigRequests, resetRequest.reconfigRequestSequenceNumber)
 	} else {
@@ -4419,6 +4451,14 @@ func (a *Association) MaxMessageSize() uint32 {
 // SetMaxMessageSize sets the maximum message size you can send.
 func (a *Association) SetMaxMessageSize(maxMsgSize uint32) {
 	atomic.StoreUint32(&a.maxMessageSize, maxMsgSize)
+}
+
+// OnStreamResetComplete sets a handler invoked after an incoming stream reset
+// completes and the stream has been removed from the association.
+func (a *Association) OnStreamResetComplete(f func(streamID uint16)) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	a.onStreamResetCompleteHandler = f
 }
 
 // completeHandshake sends the given error to  handshakeCompletedCh unless the read/write

--- a/association.go
+++ b/association.go
@@ -2096,6 +2096,18 @@ func (a *Association) handleInit(pkt *packet, initChunk *chunkInit) ([]*packet, 
 	// responding, the endpoint MUST send the INIT ACK back to the same
 	// address that the original INIT (sent by this endpoint) was sent.
 
+	if state == established &&
+		a.sourcePort == pkt.destinationPort &&
+		a.destinationPort == pkt.sourcePort &&
+		a.peerVerificationTag == initChunk.initiateTag {
+		// An INIT retransmitted by the peer can arrive after its COOKIE ECHO
+		// established this association. It belongs to the current handshake,
+		// so it must not tear down or mutate the live TCB.
+		a.log.Debugf("[%s] ignoring duplicate INIT for established association", a.name)
+
+		return nil, nil
+	}
+
 	if state != closed && state != cookieWait && state != cookieEchoed {
 		// 5.2.2.  Unexpected INIT in States Other than CLOSED, COOKIE-ECHOED,
 		//        COOKIE-WAIT, and SHUTDOWN-ACK-SENT

--- a/association.go
+++ b/association.go
@@ -2688,14 +2688,14 @@ func (a *Association) getOrCreateStream(
 //
 //nolint:gocognit,cyclop
 func (a *Association) processSelectiveAck(selectiveAckChunk *chunkSelectiveAck) (
-	bytesAckedPerStream map[uint16]int,
+	bytesAckedPerStream map[*Stream]int,
 	htna uint32,
 	newestDeliveredSendTime time.Time,
 	newestDeliveredOrigTSN uint32,
 	deliveredFound bool,
 	err error,
 ) {
-	bytesAckedPerStream = map[uint16]int{}
+	bytesAckedPerStream = map[*Stream]int{}
 	now := time.Now() // capture the time for this SACK
 
 	// Validate that full range exists in the inflight queue to prevent partial pops
@@ -2759,11 +2759,11 @@ func (a *Association) processSelectiveAck(selectiveAckChunk *chunkSelectiveAck) 
 
 			nBytesAcked := len(chunkPayload.userData)
 
-			// Sum the number of bytes acknowledged per stream
-			if amount, ok := bytesAckedPerStream[chunkPayload.streamIdentifier]; ok {
-				bytesAckedPerStream[chunkPayload.streamIdentifier] = amount + nBytesAcked
-			} else {
-				bytesAckedPerStream[chunkPayload.streamIdentifier] = nBytesAcked
+			// Sum acknowledged bytes against the stream generation that sent
+			// the chunk. A reset can remove that stream and allow the same ID to
+			// name a new stream before a delayed SACK arrives.
+			if stream := a.streamForAcknowledgedChunk(chunkPayload); stream != nil {
+				bytesAckedPerStream[stream] += nBytesAcked
 			}
 
 			// RFC 4960 sec 6.3.1.  RTO Calculation
@@ -2825,11 +2825,10 @@ func (a *Association) processSelectiveAck(selectiveAckChunk *chunkSelectiveAck) 
 			if !chunkPayload.acked { //nolint:nestif
 				nBytesAcked := a.inflightQueue.markAsAcked(tsn)
 
-				// Sum the number of bytes acknowledged per stream
-				if amount, ok := bytesAckedPerStream[chunkPayload.streamIdentifier]; ok {
-					bytesAckedPerStream[chunkPayload.streamIdentifier] = amount + nBytesAcked
-				} else {
-					bytesAckedPerStream[chunkPayload.streamIdentifier] = nBytesAcked
+				// Sum acknowledged bytes against the stream generation that sent
+				// the chunk, not a later stream that reused its identifier.
+				if stream := a.streamForAcknowledgedChunk(chunkPayload); stream != nil {
+					bytesAckedPerStream[stream] += nBytesAcked
 				}
 
 				a.log.Tracef("[%s] tsn=%d has been sacked", a.name, chunkPayload.tsn)
@@ -2864,6 +2863,15 @@ func (a *Association) processSelectiveAck(selectiveAckChunk *chunkSelectiveAck) 
 	}
 
 	return bytesAckedPerStream, htna, newestDeliveredSendTime, newestDeliveredOrigTSN, deliveredFound, nil
+}
+
+// The caller should hold the association lock.
+func (a *Association) streamForAcknowledgedChunk(chunk *chunkPayloadData) *Stream {
+	if chunk.stream != nil {
+		return chunk.stream
+	}
+
+	return a.streams[chunk.streamIdentifier]
 }
 
 // The caller should hold the lock.
@@ -3055,12 +3063,10 @@ func (a *Association) processAcknowledgement(
 		a.onCumulativeTSNAckPointAdvanced(totalBytesAcked)
 	}
 
-	for si, nBytesAcked := range bytesAckedPerStream {
-		if s, ok := a.streams[si]; ok {
-			a.lock.Unlock()
-			s.onBufferReleased(nBytesAcked)
-			a.lock.Lock()
-		}
+	for stream, nBytesAcked := range bytesAckedPerStream {
+		a.lock.Unlock()
+		stream.onBufferReleased(nBytesAcked)
+		a.lock.Lock()
 	}
 
 	return acknowledgementResult{

--- a/association.go
+++ b/association.go
@@ -280,8 +280,10 @@ type Association struct {
 
 	// Reconfig
 	myNextRSN                    uint32
+	peerNextRSN                  uint32
 	reconfigs                    map[uint32]*chunkReconfig
 	reconfigRequests             map[uint32]*paramOutgoingResetRequest
+	lastReconfigResponse         *packet
 	onStreamResetCompleteHandler func(streamID uint16)
 	streamResetStates            map[uint16]streamResetState
 
@@ -639,6 +641,12 @@ func (c Config) applyServer(cfg *Config) error { //nolint:dupl,cyclop
 	if c.CwndCAStep != 0 {
 		cfg.CwndCAStep = c.CwndCAStep
 	}
+	if c.NumInboundStreams != 0 {
+		cfg.NumInboundStreams = c.NumInboundStreams
+	}
+	if c.NumOutboundStreams != 0 {
+		cfg.NumOutboundStreams = c.NumOutboundStreams
+	}
 
 	cfg.rack = c.rack
 	cfg.interleaving = cloneInterleavingSettings(c.interleaving)
@@ -760,6 +768,12 @@ func (c Config) applyClient(cfg *Config) error { //nolint:dupl,cyclop
 	}
 	if c.CwndCAStep != 0 {
 		cfg.CwndCAStep = c.CwndCAStep
+	}
+	if c.NumInboundStreams != 0 {
+		cfg.NumInboundStreams = c.NumInboundStreams
+	}
+	if c.NumOutboundStreams != 0 {
+		cfg.NumOutboundStreams = c.NumOutboundStreams
 	}
 
 	cfg.rack = c.rack
@@ -939,6 +953,7 @@ func (a *Association) initWithOutOfBandTokens(localInit *chunkInit, remoteInit *
 	a.localOutboundStreams = localInit.numOutboundStreams
 	a.peerInboundStreams = remoteInit.numInboundStreams
 	a.peerOutboundStreams = remoteInit.numOutboundStreams
+	a.peerNextRSN = remoteInit.initialTSN
 	a.setRWND(remoteInit.advertisedReceiverWindowCredit)
 	a.peerVerificationTag = remoteInit.initiateTag
 	a.sourcePort = defaultSCTPSrcDstPort
@@ -2138,6 +2153,8 @@ func (a *Association) handleInit(pkt *packet, initChunk *chunkInit) ([]*packet, 
 	//  https://www.rfc-editor.org/rfc/rfc9260#sec_handle_stream_parameters
 	a.peerInboundStreams = initChunk.numInboundStreams
 	a.peerOutboundStreams = initChunk.numOutboundStreams
+	a.peerNextRSN = initChunk.initialTSN
+	a.lastReconfigResponse = nil
 	a.peerVerificationTag = initChunk.initiateTag
 	a.sourcePort = pkt.destinationPort
 	a.destinationPort = pkt.sourcePort
@@ -2234,6 +2251,8 @@ func (a *Association) handleInitAck(pkt *packet, initChunkAck *chunkInitAck) err
 
 	a.peerInboundStreams = initChunkAck.numInboundStreams
 	a.peerOutboundStreams = initChunkAck.numOutboundStreams
+	a.peerNextRSN = initChunkAck.initialTSN
+	a.lastReconfigResponse = nil
 	a.peerVerificationTag = initChunkAck.initiateTag
 	a.payloadQueue.init(initChunkAck.initialTSN - 1)
 	if a.sourcePort != pkt.destinationPort ||
@@ -3687,6 +3706,16 @@ func (a *Association) handleReconfigParam(raw param) (*packet, error) {
 	switch par := raw.(type) {
 	case *paramOutgoingResetRequest:
 		a.log.Tracef("[%s] handleReconfigParam (OutgoingResetRequest)", a.name)
+		if par.reconfigRequestSequenceNumber != a.peerNextRSN {
+			if par.reconfigRequestSequenceNumber == a.peerNextRSN-1 && a.lastReconfigResponse != nil {
+				return a.lastReconfigResponse, nil
+			}
+
+			return a.createReconfigResponse(
+				par.reconfigRequestSequenceNumber,
+				reconfigResultErrorBadSequenceNumber,
+			), nil
+		}
 		if a.peerLastTSN() < par.senderLastTSN && len(a.reconfigRequests) >= maxReconfigRequests {
 			// We have too many reconfig requests outstanding. Drop the request and let
 			// the peer retransmit. A well behaved peer should only have 1 outstanding
@@ -3700,6 +3729,7 @@ func (a *Association) handleReconfigParam(raw param) (*packet, error) {
 			// https://chromium.googlesource.com/external/webrtc/+/refs/heads/main/net/dcsctp/socket/stream_reset_handler.cc#271
 			return nil, fmt.Errorf("%w: %d", ErrTooManyReconfigRequests, len(a.reconfigRequests))
 		}
+		a.peerNextRSN++
 		a.reconfigRequests[par.reconfigRequestSequenceNumber] = par
 		resp := a.resetStreamsIfAny(par)
 		if resp != nil {
@@ -3780,9 +3810,17 @@ func (a *Association) resetStreamsIfAny(resetRequest *paramOutgoingResetRequest)
 		result = reconfigResultInProgress
 	}
 
+	response := a.createReconfigResponse(resetRequest.reconfigRequestSequenceNumber, result)
+	a.lastReconfigResponse = response
+
+	return response
+}
+
+// The caller should hold the association lock.
+func (a *Association) createReconfigResponse(sequenceNumber uint32, result reconfigResult) *packet {
 	return a.createPacket([]chunk{&chunkReconfig{
 		paramA: &paramReconfigResponse{
-			reconfigResponseSequenceNumber: resetRequest.reconfigRequestSequenceNumber,
+			reconfigResponseSequenceNumber: sequenceNumber,
 			result:                         result,
 		},
 	}})

--- a/association.go
+++ b/association.go
@@ -421,6 +421,9 @@ type Config struct {
 	MaxMessageSize       uint32
 	// RTOMax is the maximum retransmission timeout in milliseconds
 	RTOMax float64
+	// HandshakeRTOMax is the maximum retransmission timeout in milliseconds for
+	// T1-init and T1-cookie. Zero inherits RTOMax.
+	HandshakeRTOMax float64
 	// Minimum congestion window
 	MinCwnd uint32
 	// Send window for fast retransmit
@@ -624,6 +627,9 @@ func (c Config) applyServer(cfg *Config) error { //nolint:dupl,cyclop
 	if c.RTOMax != 0 {
 		cfg.RTOMax = c.RTOMax
 	}
+	if c.HandshakeRTOMax != 0 {
+		cfg.HandshakeRTOMax = c.HandshakeRTOMax
+	}
 	if c.MinCwnd != 0 {
 		cfg.MinCwnd = c.MinCwnd
 	}
@@ -743,6 +749,9 @@ func (c Config) applyClient(cfg *Config) error { //nolint:dupl,cyclop
 	if c.RTOMax != 0 {
 		cfg.RTOMax = c.RTOMax
 	}
+	if c.HandshakeRTOMax != 0 {
+		cfg.HandshakeRTOMax = c.HandshakeRTOMax
+	}
 	if c.MinCwnd != 0 {
 		cfg.MinCwnd = c.MinCwnd
 	}
@@ -816,6 +825,7 @@ func createAssociationFromConfigWithTsn(cfg *Config, tsn uint32) *Association {
 	}
 
 	rtoMax := cfg.RTOMax
+	handshakeRTOMax := effectiveHandshakeRTOMax(rtoMax, cfg.HandshakeRTOMax)
 	interleaving := cfg.interleaving
 	if interleaving == nil {
 		interleaving = &interleavingSettings{}
@@ -899,14 +909,22 @@ func createAssociationFromConfigWithTsn(cfg *Config, tsn uint32) *Association {
 		assoc.name, assoc.CWND(), assoc.ssthresh, assoc.inflightQueue.getNumBytes())
 
 	assoc.srtt.Store(float64(0))
-	assoc.t1Init = newRTXTimer(timerT1Init, assoc, maxInitRetrans, rtoMax)
-	assoc.t1Cookie = newRTXTimer(timerT1Cookie, assoc, maxInitRetrans, rtoMax)
+	assoc.t1Init = newRTXTimer(timerT1Init, assoc, maxInitRetrans, handshakeRTOMax)
+	assoc.t1Cookie = newRTXTimer(timerT1Cookie, assoc, maxInitRetrans, handshakeRTOMax)
 	assoc.t2Shutdown = newRTXTimer(timerT2Shutdown, assoc, noMaxRetrans, rtoMax)
 	assoc.t3RTX = newRTXTimer(timerT3RTX, assoc, noMaxRetrans, rtoMax)
 	assoc.tReconfig = newRTXTimer(timerReconfig, assoc, noMaxRetrans, rtoMax)
 	assoc.ackTimer = newAckTimer(assoc)
 
 	return assoc
+}
+
+func effectiveHandshakeRTOMax(rtoMax, handshakeRTOMax float64) float64 {
+	if handshakeRTOMax == 0 {
+		return rtoMax
+	}
+
+	return handshakeRTOMax
 }
 
 func (a *Association) initWithOutOfBandTokens(localInit *chunkInit, remoteInit *chunkInit) error {

--- a/association_options.go
+++ b/association_options.go
@@ -158,6 +158,20 @@ func WithRTOMax(rtoMax float64) AssociationOption {
 	})
 }
 
+// WithHandshakeRTOMax sets the max retransmission timeout in ms for the
+// T1-init and T1-cookie handshake timers. Other association timers retain the
+// value configured by WithRTOMax or the default.
+func WithHandshakeRTOMax(rtoMax float64) AssociationOption {
+	return sharedOption(func(c *Config) error {
+		if rtoMax <= 0 {
+			return errInvalidRTOMax
+		}
+		c.HandshakeRTOMax = rtoMax
+
+		return nil
+	})
+}
+
 // WithMinCwnd sets the minimum congestion window for the association.
 func WithMinCwnd(minCwnd uint32) AssociationOption {
 	return sharedOption(func(c *Config) error {

--- a/association_options.go
+++ b/association_options.go
@@ -185,6 +185,17 @@ func WithCwndCAStep(cwndCAStep uint32) AssociationOption {
 	})
 }
 
+// WithNumStreams sets the maximum inbound and outbound stream counts to negotiate.
+// A zero value retains the default maximum for that direction.
+func WithNumStreams(numInbound, numOutbound uint16) AssociationOption {
+	return sharedOption(func(c *Config) error {
+		c.NumInboundStreams = numInbound
+		c.NumOutboundStreams = numOutbound
+
+		return nil
+	})
+}
+
 // WithSNAP enables SNAP, https://datatracker.ietf.org/doc/draft-hancke-tsvwg-snap/.
 func WithSNAP(localSctpInit []byte, remoteSctpInit []byte) AssociationOption {
 	return sharedOption(func(c *Config) error {

--- a/association_options_test.go
+++ b/association_options_test.go
@@ -268,3 +268,25 @@ func TestAssociationRTOMaxStillIncludesHandshakeByDefault(t *testing.T) {
 	assert.Equal(t, float64(250), effectiveHandshakeRTOMax(250, 0))
 	assert.Equal(t, float64(150), effectiveHandshakeRTOMax(1000, 150))
 }
+
+func TestAssociationConfigCopiesStreamLimits(t *testing.T) {
+	const (
+		numInbound  = uint16(7)
+		numOutbound = uint16(9)
+	)
+	config := Config{
+		NetConn:            &dumbConn{},
+		NumInboundStreams:  numInbound,
+		NumOutboundStreams: numOutbound,
+	}
+
+	serverConfig, err := buildServerConfig(config)
+	assert.NoError(t, err)
+	assert.Equal(t, numInbound, serverConfig.NumInboundStreams)
+	assert.Equal(t, numOutbound, serverConfig.NumOutboundStreams)
+
+	clientConfig, err := buildClientConfig(config)
+	assert.NoError(t, err)
+	assert.Equal(t, numInbound, clientConfig.NumInboundStreams)
+	assert.Equal(t, numOutbound, clientConfig.NumOutboundStreams)
+}

--- a/association_options_test.go
+++ b/association_options_test.go
@@ -127,6 +127,9 @@ func TestAssociationOptions_Validation(t *testing.T) {
 		var cfg Config
 		err := WithRTOMax(0).applyServer(&cfg)
 		assert.ErrorIs(t, err, errInvalidRTOMax)
+
+		err = WithHandshakeRTOMax(0).applyServer(&cfg)
+		assert.ErrorIs(t, err, errInvalidRTOMax)
 	})
 
 	t.Run("snap nil arguments", func(t *testing.T) {
@@ -205,6 +208,7 @@ func TestAssociationOptions_ClientAndServer(t *testing.T) {
 		WithMaxMessageSize(30000),
 		WithMaxReassemblyQueueEntries(13),
 		WithRTOMax(1000),
+		WithHandshakeRTOMax(150),
 		WithMinCwnd(5000),
 		WithFastRtxWnd(6000),
 		WithCwndCAStep(7000),
@@ -234,6 +238,12 @@ func TestAssociationOptions_ClientAndServer(t *testing.T) {
 
 	assert.Equal(t, uint32(13), aClient.maxReassemblyQueueEntries)
 	assert.Equal(t, uint32(13), aServer.maxReassemblyQueueEntries)
+	assert.Equal(t, float64(150), aClient.t1Init.rtoMax)
+	assert.Equal(t, float64(150), aClient.t1Cookie.rtoMax)
+	assert.Equal(t, float64(1000), aClient.t3RTX.rtoMax)
+	assert.Equal(t, float64(150), aServer.t1Init.rtoMax)
+	assert.Equal(t, float64(150), aServer.t1Cookie.rtoMax)
+	assert.Equal(t, float64(1000), aServer.t3RTX.rtoMax)
 
 	assert.Equal(t, uint32(5000), aClient.minCwnd)
 	assert.Equal(t, uint32(6000), aClient.fastRtxWnd)
@@ -252,4 +262,9 @@ func TestAssociationOptions_ClientAndServer(t *testing.T) {
 	assert.Equal(t, "opt-pair", aServer.name)
 
 	time.Sleep(10 * time.Millisecond)
+}
+
+func TestAssociationRTOMaxStillIncludesHandshakeByDefault(t *testing.T) {
+	assert.Equal(t, float64(250), effectiveHandshakeRTOMax(250, 0))
+	assert.Equal(t, float64(150), effectiveHandshakeRTOMax(1000, 150))
 }

--- a/association_test.go
+++ b/association_test.go
@@ -4749,8 +4749,42 @@ func TestAssocHandleInit(t *testing.T) {
 		handleInitTest(t, closed, false)
 	})
 
-	t.Run("unexpected state established", func(t *testing.T) {
+	t.Run("unexpected new association in established state", func(t *testing.T) {
 		handleInitTest(t, established, true)
+	})
+
+	t.Run("duplicate init in established state", func(t *testing.T) {
+		assoc := createTestAssociation(t, Config{
+			NetConn:       &dumbConn{},
+			LoggerFactory: loggerFactory,
+		})
+		assoc.setState(established)
+		assoc.sourcePort = 5002
+		assoc.destinationPort = 5001
+		assoc.peerVerificationTag = 5678
+		assoc.peerInboundStreams = 11
+		assoc.peerOutboundStreams = 12
+		pkt := &packet{
+			sourcePort:      5001,
+			destinationPort: 5002,
+		}
+		init := &chunkInit{
+			chunkInitCommon: chunkInitCommon{
+				initialTSN:                     1234,
+				numOutboundStreams:             1001,
+				numInboundStreams:              1002,
+				initiateTag:                    5678,
+				advertisedReceiverWindowCredit: 512 * 1024,
+			},
+		}
+
+		packets, err := assoc.handleInit(pkt, init)
+		require.NoError(t, err)
+		assert.Empty(t, packets)
+		assert.Equal(t, established, assoc.getState())
+		assert.Equal(t, uint32(5678), assoc.peerVerificationTag)
+		assert.Equal(t, uint16(11), assoc.peerInboundStreams)
+		assert.Equal(t, uint16(12), assoc.peerOutboundStreams)
 	})
 
 	t.Run("shutdownAckSent matching ports retransmits shutdown ack", func(t *testing.T) {

--- a/association_test.go
+++ b/association_test.go
@@ -4970,12 +4970,35 @@ func TestStreamResetCompleteWaitsForRemovalAndFiresOnce(t *testing.T) {
 	response = assoc.resetStreamsIfAny(request)
 	assoc.lock.Unlock()
 	require.Equal(t, reconfigResultSuccessPerformed, resetResponseResult(t, response))
+	select {
+	case id := <-completed:
+		t.Fatalf("reset completion fired before outgoing reset for stream %d", id)
+	default:
+	}
+
+	const outgoingSequence = uint32(2)
+	assoc.reconfigs[outgoingSequence] = &chunkReconfig{
+		paramA: &paramOutgoingResetRequest{
+			reconfigRequestSequenceNumber: outgoingSequence,
+			streamIdentifiers:             []uint16{streamID},
+		},
+	}
+	assoc.lock.Lock()
+	_, err := assoc.handleReconfigParam(&paramReconfigResponse{
+		reconfigResponseSequenceNumber: outgoingSequence,
+		result:                         reconfigResultSuccessPerformed,
+	})
+	assoc.lock.Unlock()
+	require.NoError(t, err)
 	require.Equal(t, streamID, <-completed)
 
 	assoc.lock.Lock()
-	response = assoc.resetStreamsIfAny(request)
+	_, err = assoc.handleReconfigParam(&paramReconfigResponse{
+		reconfigResponseSequenceNumber: outgoingSequence,
+		result:                         reconfigResultSuccessPerformed,
+	})
 	assoc.lock.Unlock()
-	require.Equal(t, reconfigResultSuccessPerformed, resetResponseResult(t, response))
+	require.NoError(t, err)
 	select {
 	case id := <-completed:
 		t.Fatalf("reset completion fired twice for stream %d", id)
@@ -5012,10 +5035,9 @@ func TestStreamResetCompleteNotifiesBothAssociations(t *testing.T) {
 	})
 
 	require.NoError(t, clientStream.Close())
+	require.NoError(t, serverStream.Close())
 	serverEvent := waitForResetEvent(t, bridge, serverCompleted)
 	require.Equal(t, streamResetEvent{id: streamID}, serverEvent)
-
-	require.NoError(t, serverStream.Close())
 	clientEvent := waitForResetEvent(t, bridge, clientCompleted)
 	require.Equal(t, streamResetEvent{id: streamID}, clientEvent)
 

--- a/association_test.go
+++ b/association_test.go
@@ -6975,6 +6975,34 @@ func TestHandleSack_ReversedGapDoesNotPartiallyProcess(t *testing.T) {
 	assert.False(t, assoc.t3RTX.isRunning())
 }
 
+func TestHandleSackCreditsOriginalStreamAfterIDReuse(t *testing.T) {
+	assoc := newRackTestAssoc(t)
+	t.Cleanup(assoc.closeAllTimers)
+	assoc.setRWND(1024)
+
+	const streamID = 1
+	oldStream := assoc.createStream(streamID, false)
+	oldStream.bufferedAmount = 1
+	chunk := mkChunk(100, time.Now())
+	chunk.stream = oldStream
+	assoc.inflightQueue.pushNoCheck(chunk)
+
+	delete(assoc.streams, streamID)
+	newStream := assoc.createStream(streamID, false)
+	newStream.bufferedAmount = 7
+
+	assoc.lock.Lock()
+	err := assoc.handleSack(&chunkSelectiveAck{
+		cumulativeTSNAck:               100,
+		advertisedReceiverWindowCredit: 1024,
+	})
+	assoc.lock.Unlock()
+
+	require.NoError(t, err)
+	assert.Zero(t, oldStream.BufferedAmount())
+	assert.Equal(t, uint64(7), newStream.BufferedAmount())
+}
+
 func TestProcessSelectiveAck_CumulativeTSNWrap(t *testing.T) {
 	assoc := newRackTestAssoc(t)
 	assoc.cumulativeTSNAckPoint = math.MaxUint32 - 1

--- a/association_test.go
+++ b/association_test.go
@@ -5078,6 +5078,77 @@ func TestStreamResetCompleteNotifiesBothAssociations(t *testing.T) {
 	closeAssociationPair(bridge, client, server)
 }
 
+func TestStreamResetRetransmissionDoesNotResetReusedStream(t *testing.T) {
+	const (
+		streamID       = uint16(7)
+		firstSequence  = uint32(101)
+		secondSequence = firstSequence + 1
+	)
+	assoc := createTestAssociation(t, Config{})
+	assoc.setState(established)
+	assoc.payloadQueue.init(100)
+	assoc.peerNextRSN = firstSequence
+	oldStream := assoc.createStream(streamID, false)
+	require.NotNil(t, oldStream)
+
+	completed := make(chan uint16, 2)
+	assoc.OnStreamResetComplete(func(id uint16) {
+		completed <- id
+	})
+
+	assoc.lock.Lock()
+	assoc.completeStreamResetDirection(streamID, streamResetOutbound)
+	response, err := assoc.handleReconfigParam(&paramOutgoingResetRequest{
+		reconfigRequestSequenceNumber: firstSequence,
+		senderLastTSN:                 100,
+		streamIdentifiers:             []uint16{streamID},
+	})
+	assoc.lock.Unlock()
+	require.NoError(t, err)
+	require.Equal(t, reconfigResultSuccessPerformed, resetResponseResult(t, response))
+	require.Equal(t, streamID, <-completed)
+
+	newStream := assoc.createStream(streamID, false)
+	require.NotNil(t, newStream)
+
+	assoc.lock.Lock()
+	response, err = assoc.handleReconfigParam(&paramOutgoingResetRequest{
+		reconfigRequestSequenceNumber: firstSequence,
+		senderLastTSN:                 100,
+		streamIdentifiers:             []uint16{streamID},
+	})
+	assoc.lock.Unlock()
+	require.NoError(t, err)
+	require.Equal(t, reconfigResultSuccessPerformed, resetResponseResult(t, response))
+	assert.Same(t, newStream, assoc.streams[streamID])
+
+	assoc.lock.Lock()
+	response, err = assoc.handleReconfigParam(&paramOutgoingResetRequest{
+		reconfigRequestSequenceNumber: secondSequence,
+		senderLastTSN:                 100,
+	})
+	assoc.lock.Unlock()
+	require.NoError(t, err)
+	require.Equal(t, reconfigResultSuccessPerformed, resetResponseResult(t, response))
+
+	assoc.lock.Lock()
+	response, err = assoc.handleReconfigParam(&paramOutgoingResetRequest{
+		reconfigRequestSequenceNumber: firstSequence,
+		senderLastTSN:                 100,
+		streamIdentifiers:             []uint16{streamID},
+	})
+	assoc.lock.Unlock()
+	require.NoError(t, err)
+	require.Equal(t, reconfigResultErrorBadSequenceNumber, resetResponseResult(t, response))
+	assert.Same(t, newStream, assoc.streams[streamID])
+
+	select {
+	case id := <-completed:
+		t.Fatalf("reset completion fired twice for stream %d", id)
+	default:
+	}
+}
+
 func resetResponseResult(t *testing.T, packet *packet) reconfigResult { //nolint:thelper
 	t.Helper()
 	require.NotNil(t, packet)

--- a/association_test.go
+++ b/association_test.go
@@ -185,6 +185,62 @@ func association( //nolint:cyclop
 	return client, server, nil
 }
 
+func associationWithClientServerOptions( //nolint:cyclop
+	t *testing.T,
+	piper piperFunc,
+	clientExtra []ClientOption,
+	serverExtra []ServerOption,
+) (*Association, *Association, error) {
+	t.Helper()
+
+	ca, cb := piper(t)
+	loggerFactory := logging.NewDefaultLoggerFactory()
+	clientOpts := append([]ClientOption{WithNetConn(ca), WithLoggerFactory(loggerFactory)}, clientExtra...)
+	serverOpts := append([]ServerOption{WithNetConn(cb), WithLoggerFactory(loggerFactory)}, serverExtra...)
+
+	type result struct {
+		side  bool
+		assoc *Association
+		err   error
+	}
+	results := make(chan result, 2)
+	go func() {
+		assoc, err := ClientWithOptions(clientOpts...)
+		results <- result{side: true, assoc: assoc, err: err}
+	}()
+	go func() {
+		assoc, err := ServerWithOptions(serverOpts...)
+		results <- result{assoc: assoc, err: err}
+	}()
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	var client, server *Association
+	for client == nil || server == nil {
+		select {
+		case res := <-results:
+			if res.err != nil {
+				_ = ca.Close()
+				_ = cb.Close()
+
+				return nil, nil, res.err
+			}
+			if res.side {
+				client = res.assoc
+			} else {
+				server = res.assoc
+			}
+		case <-timer.C:
+			_ = ca.Close()
+			_ = cb.Close()
+
+			return nil, nil, fmt.Errorf("timeout establishing association") //nolint:err113
+		}
+	}
+
+	return client, server, nil
+}
+
 type piperFunc func(t *testing.T) (net.Conn, net.Conn)
 
 func pipeDump(t *testing.T) (net.Conn, net.Conn) {
@@ -881,6 +937,8 @@ func TestAssociationMetadataJSON(t *testing.T) {
 		PartialReliabilityMode:       PartialReliabilityModeIForwardTSN,
 		ZeroChecksumSendingEnabled:   true,
 		ZeroChecksumReceivingEnabled: true,
+		NumInboundStreams:            10,
+		NumOutboundStreams:           20,
 	}
 
 	raw, err := json.Marshal(metadata)
@@ -889,7 +947,9 @@ func TestAssociationMetadataJSON(t *testing.T) {
 		"messageInterleavingEnabled": true,
 		"partialReliabilityMode": 2,
 		"zeroChecksumSendingEnabled": true,
-		"zeroChecksumReceivingEnabled": true
+		"zeroChecksumReceivingEnabled": true,
+		"numInboundStreams": 10,
+		"numOutboundStreams": 20
 	}`, string(raw))
 }
 
@@ -4677,8 +4737,8 @@ func TestAssocHandleInit(t *testing.T) {
 		}
 		assert.NoError(t, err, "should succeed")
 		assert.Equal(t, init.initialTSN-1, assoc.peerLastTSN(), "should match")
-		assert.Equal(t, uint16(1001), assoc.myMaxNumOutboundStreams, "should match")
-		assert.Equal(t, uint16(1002), assoc.myMaxNumInboundStreams, "should match")
+		assert.Equal(t, uint16(1001), assoc.peerOutboundStreams, "should match")
+		assert.Equal(t, uint16(1002), assoc.peerInboundStreams, "should match")
 		assert.Equal(t, uint32(5678), assoc.peerVerificationTag, "should match")
 		assert.Equal(t, pkt.sourcePort, assoc.destinationPort, "should match")
 		assert.Equal(t, pkt.destinationPort, assoc.sourcePort, "should match")
@@ -4841,6 +4901,154 @@ func TestAssocMaxMessageSize(t *testing.T) {
 		a.SetMaxMessageSize(20000)
 		assert.Equal(t, uint32(20000), a.MaxMessageSize(), "should match")
 	})
+}
+
+func TestAssociationMetadataReportsNegotiatedStreamLimits(t *testing.T) {
+	const (
+		clientInbound  = uint16(3)
+		clientOutbound = uint16(4)
+		serverInbound  = uint16(11)
+		serverOutbound = uint16(12)
+	)
+
+	client, server, err := associationWithClientServerOptions(
+		t,
+		pipeDump,
+		[]ClientOption{WithNumStreams(clientInbound, clientOutbound)},
+		[]ServerOption{WithNumStreams(serverInbound, serverOutbound)},
+	)
+	require.NoError(t, err)
+	defer noErrorClose(t, client.Close)
+	defer noErrorClose(t, server.Close)
+
+	clientMetadata, ok := client.Metadata()
+	require.True(t, ok)
+	require.Equal(t, clientInbound, clientMetadata.NumInboundStreams)
+	require.Equal(t, clientOutbound, clientMetadata.NumOutboundStreams)
+
+	serverMetadata, ok := server.Metadata()
+	require.True(t, ok)
+	require.Equal(t, clientOutbound, serverMetadata.NumInboundStreams)
+	require.Equal(t, clientInbound, serverMetadata.NumOutboundStreams)
+}
+
+func TestStreamResetCompleteWaitsForRemovalAndFiresOnce(t *testing.T) {
+	const streamID = uint16(7)
+	assoc := createTestAssociation(t, Config{})
+	assoc.setState(established)
+	assoc.payloadQueue.init(100)
+	stream := assoc.createStream(streamID, false)
+	require.NotNil(t, stream)
+
+	completed := make(chan uint16, 2)
+	assoc.OnStreamResetComplete(func(id uint16) {
+		assoc.lock.RLock()
+		_, present := assoc.streams[id]
+		assoc.lock.RUnlock()
+		require.False(t, present)
+		completed <- id
+	})
+
+	request := &paramOutgoingResetRequest{
+		reconfigRequestSequenceNumber: 1,
+		senderLastTSN:                 101,
+		streamIdentifiers:             []uint16{streamID},
+	}
+
+	assoc.lock.Lock()
+	response := assoc.resetStreamsIfAny(request)
+	assoc.lock.Unlock()
+	require.Equal(t, reconfigResultInProgress, resetResponseResult(t, response))
+	select {
+	case id := <-completed:
+		t.Fatalf("reset completion fired early for stream %d", id)
+	default:
+	}
+
+	assoc.payloadQueue.init(101)
+	assoc.lock.Lock()
+	response = assoc.resetStreamsIfAny(request)
+	assoc.lock.Unlock()
+	require.Equal(t, reconfigResultSuccessPerformed, resetResponseResult(t, response))
+	require.Equal(t, streamID, <-completed)
+
+	assoc.lock.Lock()
+	response = assoc.resetStreamsIfAny(request)
+	assoc.lock.Unlock()
+	require.Equal(t, reconfigResultSuccessPerformed, resetResponseResult(t, response))
+	select {
+	case id := <-completed:
+		t.Fatalf("reset completion fired twice for stream %d", id)
+	default:
+	}
+}
+
+type streamResetEvent struct {
+	id      uint16
+	present bool
+}
+
+func TestStreamResetCompleteNotifiesBothAssociations(t *testing.T) {
+	const streamID = uint16(5)
+	bridge := test.NewBridge()
+	client, server, err := createNewAssociationPair(bridge, ackModeNoDelay, 0)
+	require.NoError(t, err)
+	clientStream, serverStream, err := establishSessionPair(bridge, client, server, streamID)
+	require.NoError(t, err)
+
+	clientCompleted := make(chan streamResetEvent, 1)
+	serverCompleted := make(chan streamResetEvent, 1)
+	client.OnStreamResetComplete(func(id uint16) {
+		client.lock.RLock()
+		_, present := client.streams[id]
+		client.lock.RUnlock()
+		clientCompleted <- streamResetEvent{id: id, present: present}
+	})
+	server.OnStreamResetComplete(func(id uint16) {
+		server.lock.RLock()
+		_, present := server.streams[id]
+		server.lock.RUnlock()
+		serverCompleted <- streamResetEvent{id: id, present: present}
+	})
+
+	require.NoError(t, clientStream.Close())
+	serverEvent := waitForResetEvent(t, bridge, serverCompleted)
+	require.Equal(t, streamResetEvent{id: streamID}, serverEvent)
+
+	require.NoError(t, serverStream.Close())
+	clientEvent := waitForResetEvent(t, bridge, clientCompleted)
+	require.Equal(t, streamResetEvent{id: streamID}, clientEvent)
+
+	closeAssociationPair(bridge, client, server)
+}
+
+func resetResponseResult(t *testing.T, packet *packet) reconfigResult { //nolint:thelper
+	t.Helper()
+	require.NotNil(t, packet)
+	require.Len(t, packet.chunks, 1)
+	reconfig, ok := packet.chunks[0].(*chunkReconfig)
+	require.True(t, ok)
+	response, ok := reconfig.paramA.(*paramReconfigResponse)
+	require.True(t, ok)
+
+	return response.result
+}
+
+func waitForResetEvent(t *testing.T, bridge *test.Bridge, events <-chan streamResetEvent) streamResetEvent {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		bridge.Process()
+		select {
+		case event := <-events:
+			return event
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	t.Fatal("timed out waiting for stream reset completion")
+
+	return streamResetEvent{}
 }
 
 type dumbConnInboundHandler func([]byte)

--- a/chunk_payload_data.go
+++ b/chunk_payload_data.go
@@ -48,6 +48,7 @@ a multi-fragment user message, as summarized in the following table:
 */
 type chunkPayloadData struct {
 	chunkHeader
+	stream *Stream
 
 	unordered         bool
 	beginningFragment bool

--- a/pending_queue.go
+++ b/pending_queue.go
@@ -363,6 +363,7 @@ func (q *weightedFairQueueingPendingQueuePolicy) Pop(chunkPayload StreamSchedule
 	delete(q.chunkFinish, chunkPayload.chunkPayloadData())
 	if streamQueue.size() == 0 {
 		delete(q.streamQueues, q.selectedStream)
+		delete(q.streamFinish, q.selectedStream)
 	}
 
 	q.streamSelected = false

--- a/pending_queue_test.go
+++ b/pending_queue_test.go
@@ -425,6 +425,21 @@ func TestWeightedFairQueueingPendingQueuePolicy(t *testing.T) {
 		assert.NoError(t, pq.Pop(chunkPayload))
 	})
 
+	t.Run("releases inactive stream state", func(t *testing.T) {
+		pq := newWeightedFairQueueingPendingQueuePolicy(nil)
+
+		for streamID := range uint16(10000) {
+			pq.Push(makeStreamDataChunk(uint32(streamID), streamID))
+			chunkPayload := pq.Peek()
+			assert.NotNil(t, chunkPayload)
+			assert.NoError(t, pq.Pop(chunkPayload))
+		}
+
+		assert.Empty(t, pq.streamQueues)
+		assert.Empty(t, pq.streamFinish)
+		assert.Empty(t, pq.chunkFinish)
+	})
+
 	t.Run("pop errors", func(t *testing.T) {
 		t.Run("requires selection", func(t *testing.T) {
 			pq := newWeightedFairQueueingPendingQueuePolicy(nil)

--- a/stream.go
+++ b/stream.go
@@ -403,6 +403,7 @@ func (s *Stream) packetize(raw []byte, ppi PayloadProtocolIdentifier) ([]*chunkP
 		copy(userData, raw[offset:offset+fragmentSize])
 
 		chunk := &chunkPayloadData{
+			stream:                 s,
 			streamIdentifier:       s.streamIdentifier,
 			userData:               userData,
 			unordered:              unordered,


### PR DESCRIPTION
## What changed

- expose reset-completion notifications and negotiated stream limits
- retain stream ownership until both reset directions have completed
- keep delayed acknowledgements and retransmitted reset requests from affecting a reused stream ID
- preserve established associations when a duplicate INIT arrives
- separate handshake retransmission limits from data retransmission limits
- copy configured inbound and outbound stream limits into client and server association options

## Why

WebRTC needs to reuse SCTP stream IDs after a DataChannel closes, but an ID is not safe to reuse until the reset procedure has completed. Delayed acknowledgements or a retransmitted reset request from the previous stream generation must also not close or mutate the new generation.

The handshake retry limit is separated because using the data retransmission limit for INIT/COOKIE retries can either terminate association setup too early or make data retransmission behavior unexpectedly permissive.

## Relationship to #463

This is an alternative implementation that covers the stream-limit and reset-completion goals of #463 and adds the lifecycle and retransmission handling needed by the corresponding WebRTC integration.

This PR is not intended to invalidate the work in #463. If maintainers prefer to continue with #463, please feel free to close this PR and reuse or adapt any tests and fixes that are useful.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `staticcheck .`
