### PR TITLE
Expose User Initiated Abort through errors.Is

### DIFF
--- a/association.go
+++ b/association.go
@@ -68,23 +68,6 @@ var (
 	ErrTooManyReconfigRequests    = errors.New("too many outstanding reconfig requests")
 )
 
-type abortError struct {
-	message               string
-	hasUserInitiatedAbort bool
-}
-
-func (e *abortError) Error() string {
-	return e.message
-}
-
-func (e *abortError) Is(target error) bool {
-	return target == ErrUserInitiatedAbort && e.hasUserInitiatedAbort
-}
-
-func (e *abortError) Unwrap() error {
-	return ErrChunk
-}
-
 const (
 	receiveMTU            uint32 = 8192 // MTU for inbound packet (from DTLS)
 	initialMTU            uint32 = 1191 // initial MTU for outgoing packets (to DTLS)
@@ -3371,10 +3354,11 @@ func (a *Association) handleAbort(c *chunkAbort) error {
 
 	_ = a.close()
 
-	return &abortError{
-		message:               fmt.Sprintf("[%s] %s: %s", a.name, ErrChunk, errStr.String()),
-		hasUserInitiatedAbort: hasUserInitiatedAbort,
+	if hasUserInitiatedAbort {
+		return fmt.Errorf("[%s] %w: %w: %s", a.name, ErrChunk, ErrUserInitiatedAbort, errStr.String())
 	}
+
+	return fmt.Errorf("[%s] %w: %s", a.name, ErrChunk, errStr.String())
 }
 
 // createForwardTSN generates ForwardTSN chunk.

--- a/association.go
+++ b/association.go
@@ -68,6 +68,23 @@ var (
 	ErrTooManyReconfigRequests    = errors.New("too many outstanding reconfig requests")
 )
 
+type abortError struct {
+	message               string
+	hasUserInitiatedAbort bool
+}
+
+func (e *abortError) Error() string {
+	return e.message
+}
+
+func (e *abortError) Is(target error) bool {
+	return target == ErrUserInitiatedAbort && e.hasUserInitiatedAbort
+}
+
+func (e *abortError) Unwrap() error {
+	return ErrChunk
+}
+
 const (
 	receiveMTU            uint32 = 8192 // MTU for inbound packet (from DTLS)
 	initialMTU            uint32 = 1191 // initial MTU for outgoing packets (to DTLS)
@@ -3344,13 +3361,20 @@ func (a *Association) handleShutdownComplete(_ *chunkShutdownComplete) error {
 
 func (a *Association) handleAbort(c *chunkAbort) error {
 	var errStr strings.Builder
+	hasUserInitiatedAbort := false
 	for _, e := range c.errorCauses {
 		fmt.Fprintf(&errStr, "(%s)", e)
+		if e.errorCauseCode() == userInitiatedAbort {
+			hasUserInitiatedAbort = true
+		}
 	}
 
 	_ = a.close()
 
-	return fmt.Errorf("[%s] %w: %s", a.name, ErrChunk, errStr.String())
+	return &abortError{
+		message:               fmt.Sprintf("[%s] %s: %s", a.name, ErrChunk, errStr.String()),
+		hasUserInitiatedAbort: hasUserInitiatedAbort,
+	}
 }
 
 // createForwardTSN generates ForwardTSN chunk.

--- a/association_test.go
+++ b/association_test.go
@@ -4482,7 +4482,7 @@ func TestAssocAbort(t *testing.T) {
 	packet, err := a0.marshalPacket(a0.createPacket([]chunk{abort}))
 	assert.NoError(t, err)
 
-	_, _, err = establishSessionPair(br, a0, a1, si)
+	_, remoteStream, err := establishSessionPair(br, a0, a1, si)
 	assert.NoError(t, err)
 
 	// Both associations are established
@@ -4499,6 +4499,10 @@ func TestAssocAbort(t *testing.T) {
 	// The receiving association should be closed because it got an ABORT
 	assert.Equal(t, established, a0.getState())
 	assert.Equal(t, closed, a1.getState())
+
+	_, err = remoteStream.Read(make([]byte, 1))
+	assert.ErrorIs(t, err, ErrChunk)
+	assert.False(t, errors.Is(err, ErrUserInitiatedAbort))
 
 	closeAssociationPair(br, a0, a1)
 }
@@ -5897,7 +5901,9 @@ func TestAssociation_Abort(t *testing.T) {
 
 	i, err = s21.Read(buf)
 	assert.Equal(t, i, 0, "expected no data read")
-	assert.Error(t, err, "User Initiated Abort: 1234", "expected abort reason")
+	assert.ErrorContains(t, err, "(User Initiated Abort: 1234)")
+	assert.ErrorIs(t, err, ErrChunk)
+	assert.ErrorIs(t, err, ErrUserInitiatedAbort)
 }
 
 // TestAssociation_createClientWithContext tests that the client is closed when the context is canceled.

--- a/error_cause_user_initiated_abort.go
+++ b/error_cause_user_initiated_abort.go
@@ -4,8 +4,13 @@
 package sctp
 
 import (
+	"errors"
 	"fmt"
 )
+
+// ErrUserInitiatedAbort is matched by errors.Is when a received ABORT chunk
+// contains a User Initiated Abort cause.
+var ErrUserInitiatedAbort = errors.New("user initiated abort")
 
 /*
 This error cause MAY be included in ABORT chunks that are sent


### PR DESCRIPTION
## Summary

- add `ErrUserInitiatedAbort` for received ABORT chunks containing RFC 9260 cause code 12
- preserve `ErrChunk` compatibility while exposing the specific cause through standard error wrapping
- keep other ABORT causes distinct without exporting a broader structured error API

## Testing

- `GOTOOLCHAIN=go1.24.0 GOMAXPROCS=4 go test -race ./...`
- `GOTOOLCHAIN=go1.25.0 GOMAXPROCS=4 go test -race . -run "^(TestAssocAbort|TestAssociation_Abort)$" -count=10`
- `GOTOOLCHAIN=go1.25.0 GOMAXPROCS=4 go vet ./...`
- `golangci-lint v2.10.1 run --allow-parallel-runners`

Fixes #486